### PR TITLE
Paginate through organization accounts

### DIFF
--- a/sources/aft-lambda-layer/aft-common/src/aft_common/aft_utils.py
+++ b/sources/aft-lambda-layer/aft-common/src/aft_common/aft_utils.py
@@ -635,11 +635,14 @@ def invoke_lambda(session, function_name, payload):
 
 def get_org_accounts(session):
     try:
+        accounts = []
         client = session.client("organizations")
         logger.info("Listing accounts for the org")
-        response = client.list_accounts()
-        logger.info(response)
-        return response["Accounts"]
+        paginator = client.get_paginator('list_accounts')
+        page_iterator = paginator.paginate()
+        for page in page_iterator:
+            accounts.extend(page['Accounts'])
+        return accounts
 
     except Exception as e:
         message = {

--- a/sources/aft-lambda-layer/aft-common/src/aft_common/aft_utils.py
+++ b/sources/aft-lambda-layer/aft-common/src/aft_common/aft_utils.py
@@ -642,6 +642,7 @@ def get_org_accounts(session):
         page_iterator = paginator.paginate()
         for page in page_iterator:
             accounts.extend(page['Accounts'])
+        logger.info(accounts)
         return accounts
 
     except Exception as e:


### PR DESCRIPTION
Instead of just calling `list_accounts`, paginate through organization accounts so we have the full set before trying to match id for the accounts email address.

fixes #13 