### PR TITLE
Adding blank condition and not_resources properties to avoid inaccurate drift

### DIFF
--- a/modules/aft-account-request-framework/backup.tf
+++ b/modules/aft-account-request-framework/backup.tf
@@ -16,10 +16,14 @@ resource "aws_backup_selection" "aft_controltower_backup_selection" {
   name         = "aft-controltower-backup-selection"
   plan_id      = aws_backup_plan.aft_controltower_backup_plan.id
 
+  condition {}
+  
   resources = [
     aws_dynamodb_table.aft_request_metadata.arn,
     aws_dynamodb_table.aft_request.arn,
     aws_dynamodb_table.aft_request_audit.arn,
     aws_dynamodb_table.aft_controltower_events.arn
   ]
+  
+  not_resources = []
 }


### PR DESCRIPTION
This PR is intended to address Issue #35 (and #37, which is likely a duplicate). The result has been tested successfully no longer indicating drift on subsequent runs.

```
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```