### PR TITLE
Bugfix account request pipeline

### DIFF
--- a/modules/aft-backend/main.tf
+++ b/modules/aft-backend/main.tf
@@ -3,6 +3,7 @@ data "aws_caller_identity" "current" {
 }
 
 # S3 Resources
+
 resource "aws_s3_bucket" "primary-backend-bucket" {
   provider = aws.primary_region
 
@@ -45,6 +46,34 @@ resource "aws_s3_bucket" "primary-backend-bucket" {
   }
 }
 
+resource "aws_s3_bucket_policy" "allow_AWSAFTExecution_role_primary" {
+  bucket = aws_s3_bucket.primary-backend-bucket.id
+  policy = data.aws_iam_policy_document.allow_AWSAFTExecution_primary.json
+}
+
+data "aws_iam_policy_document" "allow_AWSAFTExecution_primary" {
+  statement {
+    principals {
+      type        = "AWS"
+      identifiers = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/AWSAFTExecution"
+    }
+
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectVersion",
+      "s3:GetBucketVersioning",
+      "s3:List*",
+      "s3:PutObjectAcl",
+      "s3:PutObject"
+    ]
+
+    resources = [
+      aws_s3_bucket.primary-backend-bucket.arn,
+      "${aws_s3_bucket.primary-backend-bucket.arn}/*",
+    ]
+  }
+}
+
 resource "aws_s3_bucket_public_access_block" "primary-backend-bucket" {
   provider = aws.primary_region
 
@@ -73,6 +102,34 @@ resource "aws_s3_bucket" "secondary-backend-bucket" {
   }
   tags = {
     "Name" = "aft-backend-${data.aws_caller_identity.current.account_id}-secondary-region"
+  }
+}
+
+resource "aws_s3_bucket_policy" "allow_AWSAFTExecution_role_secondary" {
+  bucket = aws_s3_bucket.secondary-backend-bucket.id
+  policy = data.aws_iam_policy_document.allow_AWSAFTExecution_secondary.json
+}
+
+data "aws_iam_policy_document" "allow_AWSAFTExecution_primary" {
+  statement {
+    principals {
+      type        = "AWS"
+      identifiers = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/AWSAFTExecution"
+    }
+
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectVersion",
+      "s3:GetBucketVersioning",
+      "s3:List*",
+      "s3:PutObjectAcl",
+      "s3:PutObject"
+    ]
+
+    resources = [
+      aws_s3_bucket.secondary-backend-bucket.arn,
+      "${aws_s3_bucket.secondary-backend-bucket.arn}/*",
+    ]
   }
 }
 

--- a/modules/aft-code-repositories/buildspecs/ct-aft-account-request.yml
+++ b/modules/aft-code-repositories/buildspecs/ct-aft-account-request.yml
@@ -55,6 +55,12 @@ phases:
           export AWS_ACCESS_KEY_ID=$(echo ${JSON} | jq --raw-output ".Credentials[\"AccessKeyId\"]")
           export AWS_SECRET_ACCESS_KEY=$(echo ${JSON} | jq --raw-output ".Credentials[\"SecretAccessKey\"]")
           export AWS_SESSION_TOKEN=$(echo ${JSON} | jq --raw-output ".Credentials[\"SessionToken\"]")
+          #Switch to execution role
+          JSON=$(aws sts assume-role --role-arn ${AFT_ADMIN_EXEC_ARN} --role-session-name ${ROLE_SESSION_NAME})
+          #Make newly assumed role default session
+          export AWS_ACCESS_KEY_ID=$(echo ${JSON} | jq --raw-output ".Credentials[\"AccessKeyId\"]")
+          export AWS_SECRET_ACCESS_KEY=$(echo ${JSON} | jq --raw-output ".Credentials[\"SecretAccessKey\"]")
+          export AWS_SESSION_TOKEN=$(echo ${JSON} | jq --raw-output ".Credentials[\"SessionToken\"]")
           terraform init
         else
           TF_ORG_NAME=$(aws ssm get-parameter --name "/aft/config/terraform/org-name" --query "Parameter.Value" --output text)


### PR DESCRIPTION
Hello,
I found a couple errors with the account request pipeline. I was able to remediate them in my lab environment by adding a bucket policy to the backed bucket, which would allow the AWSAFTExecution role. Also, updated the buildspec for CodeBuild to assume the AWSAFTExecution role, as opposed to the AWSAFTAdmin role (Admin role doesn't have permissions on dynamodb or much else). These fixes remediated the errors that were popping up in the account request pipeline, from vanilla install of AFT (TF oss, CodeCommit VCS), after following post-deployment steps.