### PR TITLE
Feature flag: Optional public networking only

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,11 +14,13 @@ module "aft_account_provisioning_framework" {
   aft_account_provisioning_customizations_sfn_name = local.aft_account_provisioning_customizations_sfn_name
   trigger_customizations_sfn_name                  = local.trigger_customizations_sfn_name
   aft_features_sfn_name                            = local.aft_features_sfn_name
+  aft_feature_disable_private_networking           = var.aft_feature_disable_private_networking
   aft_sns_topic_arn                                = module.aft_account_request_framework.aft_sns_topic_arn
   aft_failure_sns_topic_arn                        = module.aft_account_request_framework.aft_failure_sns_topic_arn
   aft_common_layer_arn                             = module.aft_lambda_layer.layer_version_arn
   aft_kms_key_arn                                  = module.aft_account_request_framework.aft_kms_key_arn
   aft_vpc_private_subnets                          = module.aft_account_request_framework.aft_vpc_private_subnets
+  aft_vpc_public_subnets                           = module.aft_account_request_framework.aft_vpc_public_subnets
   aft_vpc_default_sg                               = module.aft_account_request_framework.aft_vpc_default_sg
   cloudwatch_log_group_retention                   = var.cloudwatch_log_group_retention
   provisioning_framework_archive_path              = module.packaging.provisioning_framework_archive_path
@@ -41,10 +43,10 @@ module "aft_account_request_framework" {
   aft_vpc_public_subnet_01_cidr               = var.aft_vpc_public_subnet_01_cidr
   aft_vpc_public_subnet_02_cidr               = var.aft_vpc_public_subnet_02_cidr
   aft_vpc_endpoints                           = var.aft_vpc_endpoints
+  aft_feature_disable_private_networking      = var.aft_feature_disable_private_networking
   request_framework_archive_path              = module.packaging.request_framework_archive_path
   request_framework_archive_hash              = module.packaging.request_framework_archive_hash
 }
-
 
 
 module "aft_backend" {
@@ -85,6 +87,7 @@ module "aft_code_repositories" {
   global_customizations_repo_branch               = var.global_customizations_repo_branch
   log_group_retention                             = var.cloudwatch_log_group_retention
   global_codebuild_timeout                        = var.global_codebuild_timeout
+    aft_feature_disable_private_networking        = var.aft_feature_disable_private_networking
 }
 
 module "aft_customizations" {
@@ -119,6 +122,7 @@ module "aft_customizations" {
   customizations_archive_path                       = module.packaging.customizations_archive_path
   customizations_archive_hash                       = module.packaging.customizations_archive_hash
   global_codebuild_timeout                          = var.global_codebuild_timeout
+    aft_feature_disable_private_networking          = var.aft_feature_disable_private_networking
 }
 
 module "aft_feature_options" {
@@ -138,15 +142,17 @@ module "aft_feature_options" {
   aft_sns_topic_arn                         = module.aft_account_request_framework.sns_topic_arn
   aft_failure_sns_topic_arn                 = module.aft_account_request_framework.failure_sns_topic_arn
   aft_vpc_private_subnets                   = module.aft_account_request_framework.aft_vpc_private_subnets
+  aft_vpc_public_subnets                    = module.aft_account_request_framework.aft_vpc_public_subnets
   aft_vpc_default_sg                        = module.aft_account_request_framework.aft_vpc_default_sg
   log_archive_account_id                    = var.log_archive_account_id
   cloudwatch_log_group_retention            = var.cloudwatch_log_group_retention
   feature_options_archive_path              = module.packaging.feature_options_archive_path
   feature_options_archive_hash              = module.packaging.feature_options_archive_hash
+  aft_feature_disable_private_networking    = var.aft_feature_disable_private_networking
 }
 
 module "aft_iam_roles" {
-  source = "./modules/aft-iam-roles"
+  source    = "./modules/aft-iam-roles"
   providers = {
     aws.ct_management  = aws.ct_management
     aws.audit          = aws.audit
@@ -170,10 +176,12 @@ module "aft_lambda_layer" {
   aft_kms_key_arn                                   = module.aft_account_request_framework.aft_kms_key_arn
   aft_vpc_id                                        = module.aft_account_request_framework.aft_vpc_id
   aft_vpc_private_subnets                           = module.aft_account_request_framework.aft_vpc_private_subnets
+  aft_vpc_public_subnets                            = module.aft_account_request_framework.aft_vpc_public_subnets
   aft_vpc_default_sg                                = module.aft_account_request_framework.aft_vpc_default_sg
   s3_bucket_name                                    = module.aft_customizations.aft_codepipeline_customizations_bucket_name
   builder_archive_path                              = module.packaging.builder_archive_path
   builder_archive_hash                              = module.packaging.builder_archive_hash
+  aft_feature_disable_private_networking            = var.aft_feature_disable_private_networking
 }
 
 module "aft_ssm_parameters" {

--- a/modules/aft-account-provisioning-framework/lambda.tf
+++ b/modules/aft-account-provisioning-framework/lambda.tf
@@ -15,9 +15,12 @@ resource "aws_lambda_function" "validate_request" {
   timeout          = 300
   layers           = [var.aft_common_layer_arn]
 
-  vpc_config {
-    subnet_ids         = var.aft_vpc_private_subnets
-    security_group_ids = var.aft_vpc_default_sg
+  dynamic "vpc_config" {
+    for_each = var.aft_feature_disable_private_networking ? {} : { k = "v" }
+    content {
+      subnet_ids            = var.aft_vpc_private_subnets
+      security_group_ids = var.aft_vpc_default_sg
+    }
   }
 }
 
@@ -41,9 +44,12 @@ resource "aws_lambda_function" "get_account_info" {
   timeout          = 300
   layers           = [var.aft_common_layer_arn]
 
-  vpc_config {
-    subnet_ids         = var.aft_vpc_private_subnets
-    security_group_ids = var.aft_vpc_default_sg
+  dynamic "vpc_config" {
+    for_each = var.aft_feature_disable_private_networking ? {} : { k = "v" }
+    content {
+      subnet_ids            = var.aft_vpc_private_subnets
+      security_group_ids = var.aft_vpc_default_sg
+    }
   }
 }
 
@@ -66,9 +72,12 @@ resource "aws_lambda_function" "create_role" {
   timeout          = 300
   layers           = [var.aft_common_layer_arn]
 
-  vpc_config {
-    subnet_ids         = var.aft_vpc_private_subnets
-    security_group_ids = var.aft_vpc_default_sg
+  dynamic "vpc_config" {
+    for_each = var.aft_feature_disable_private_networking ? {} : { k = "v" }
+    content {
+      subnet_ids            = var.aft_vpc_private_subnets
+      security_group_ids = var.aft_vpc_default_sg
+    }
   }
 }
 
@@ -92,9 +101,12 @@ resource "aws_lambda_function" "tag_account" {
   timeout          = 300
   layers           = [var.aft_common_layer_arn]
 
-  vpc_config {
-    subnet_ids         = var.aft_vpc_private_subnets
-    security_group_ids = var.aft_vpc_default_sg
+  dynamic "vpc_config" {
+    for_each = var.aft_feature_disable_private_networking ? {} : { k = "v" }
+    content {
+      subnet_ids            = var.aft_vpc_private_subnets
+      security_group_ids = var.aft_vpc_default_sg
+    }
   }
 }
 
@@ -117,9 +129,12 @@ resource "aws_lambda_function" "persist_metadata" {
   timeout          = 300
   layers           = [var.aft_common_layer_arn]
 
-  vpc_config {
-    subnet_ids         = var.aft_vpc_private_subnets
-    security_group_ids = var.aft_vpc_default_sg
+  dynamic "vpc_config" {
+    for_each = var.aft_feature_disable_private_networking ? {} : { k = "v" }
+    content {
+      subnet_ids            = var.aft_vpc_private_subnets
+      security_group_ids = var.aft_vpc_default_sg
+    }
   }
 }
 
@@ -144,9 +159,12 @@ resource "aws_lambda_function" "account_metadata_ssm" {
   timeout          = 300
   layers           = [var.aft_common_layer_arn]
 
-  vpc_config {
-    subnet_ids         = var.aft_vpc_private_subnets
-    security_group_ids = var.aft_vpc_default_sg
+  dynamic "vpc_config" {
+    for_each = var.aft_feature_disable_private_networking ? {} : { k = "v" }
+    content {
+      subnet_ids            = var.aft_vpc_private_subnets
+      security_group_ids = var.aft_vpc_default_sg
+    }
   }
 }
 

--- a/modules/aft-account-provisioning-framework/variables.tf
+++ b/modules/aft-account-provisioning-framework/variables.tf
@@ -37,7 +37,15 @@ variable "aft_features_sfn_name" {
   type = string
 }
 
+variable "aft_feature_disable_private_networking" {
+  type = bool
+}
+
 variable "aft_vpc_private_subnets" {
+  type = list(string)
+}
+
+variable "aft_vpc_public_subnets" {
   type = list(string)
 }
 

--- a/modules/aft-account-request-framework/data.tf
+++ b/modules/aft-account-request-framework/data.tf
@@ -41,7 +41,7 @@ data "aws_subnets" "codebuild" {
 
   filter {
     name   = "subnet-id"
-    values = [aws_subnet.aft_vpc_private_subnet_01.id, aws_subnet.aft_vpc_private_subnet_02.id]
+    values = local.vpc_endpoint_subnet_ids
   }
 
   filter {
@@ -64,7 +64,7 @@ data "aws_subnets" "codecommit" {
 
   filter {
     name   = "subnet-id"
-    values = [aws_subnet.aft_vpc_private_subnet_01.id, aws_subnet.aft_vpc_private_subnet_02.id]
+    values = local.vpc_endpoint_subnet_ids
   }
 
   filter {
@@ -88,7 +88,7 @@ data "aws_subnets" "git-codecommit" {
 
   filter {
     name   = "subnet-id"
-    values = [aws_subnet.aft_vpc_private_subnet_01.id, aws_subnet.aft_vpc_private_subnet_02.id]
+    values = local.vpc_endpoint_subnet_ids
   }
 
   filter {
@@ -112,7 +112,7 @@ data "aws_subnets" "codepipeline" {
 
   filter {
     name   = "subnet-id"
-    values = [aws_subnet.aft_vpc_private_subnet_01.id, aws_subnet.aft_vpc_private_subnet_02.id]
+    values = local.vpc_endpoint_subnet_ids
   }
 
   filter {
@@ -135,7 +135,7 @@ data "aws_subnets" "servicecatalog" {
 
   filter {
     name   = "subnet-id"
-    values = [aws_subnet.aft_vpc_private_subnet_01.id, aws_subnet.aft_vpc_private_subnet_02.id]
+    values = local.vpc_endpoint_subnet_ids
   }
 
   filter {
@@ -157,7 +157,7 @@ data "aws_subnets" "lambda" {
   }
   filter {
     name   = "subnet-id"
-    values = [aws_subnet.aft_vpc_private_subnet_01.id, aws_subnet.aft_vpc_private_subnet_02.id]
+    values = local.vpc_endpoint_subnet_ids
   }
 
   filter {
@@ -180,7 +180,7 @@ data "aws_subnets" "kms" {
 
   filter {
     name   = "subnet-id"
-    values = [aws_subnet.aft_vpc_private_subnet_01.id, aws_subnet.aft_vpc_private_subnet_02.id]
+    values = local.vpc_endpoint_subnet_ids
   }
 
   filter {
@@ -203,7 +203,7 @@ data "aws_subnets" "logs" {
   }
   filter {
     name   = "subnet-id"
-    values = [aws_subnet.aft_vpc_private_subnet_01.id, aws_subnet.aft_vpc_private_subnet_02.id]
+    values = local.vpc_endpoint_subnet_ids
   }
 
   filter {
@@ -226,7 +226,7 @@ data "aws_subnets" "events" {
 
   filter {
     name   = "subnet-id"
-    values = [aws_subnet.aft_vpc_private_subnet_01.id, aws_subnet.aft_vpc_private_subnet_02.id]
+    values = local.vpc_endpoint_subnet_ids
   }
 
   filter {
@@ -248,7 +248,7 @@ data "aws_subnets" "states" {
   }
   filter {
     name   = "subnet-id"
-    values = [aws_subnet.aft_vpc_private_subnet_01.id, aws_subnet.aft_vpc_private_subnet_02.id]
+    values = local.vpc_endpoint_subnet_ids
   }
 
   filter {
@@ -272,7 +272,7 @@ data "aws_subnets" "ssm" {
 
   filter {
     name   = "subnet-id"
-    values = [aws_subnet.aft_vpc_private_subnet_01.id, aws_subnet.aft_vpc_private_subnet_02.id]
+    values = local.vpc_endpoint_subnet_ids
   }
 
   filter {
@@ -295,7 +295,7 @@ data "aws_subnets" "sns" {
 
   filter {
     name   = "subnet-id"
-    values = [aws_subnet.aft_vpc_private_subnet_01.id, aws_subnet.aft_vpc_private_subnet_02.id]
+    values = local.vpc_endpoint_subnet_ids
   }
 
   filter {
@@ -318,7 +318,7 @@ data "aws_subnets" "sqs" {
 
   filter {
     name   = "subnet-id"
-    values = [aws_subnet.aft_vpc_private_subnet_01.id, aws_subnet.aft_vpc_private_subnet_02.id]
+    values = local.vpc_endpoint_subnet_ids
   }
 
   filter {
@@ -341,7 +341,7 @@ data "aws_subnets" "sts" {
 
   filter {
     name   = "subnet-id"
-    values = [aws_subnet.aft_vpc_private_subnet_01.id, aws_subnet.aft_vpc_private_subnet_02.id]
+    values = local.vpc_endpoint_subnet_ids
   }
 
   filter {

--- a/modules/aft-account-request-framework/lambda.tf
+++ b/modules/aft-account-request-framework/lambda.tf
@@ -17,11 +17,13 @@ resource "aws_lambda_function" "aft_account_request_audit_trigger" {
   timeout          = "300"
   layers           = [var.aft_common_layer_arn]
 
-  vpc_config {
-    subnet_ids         = tolist([aws_subnet.aft_vpc_private_subnet_01.id, aws_subnet.aft_vpc_private_subnet_02.id])
-    security_group_ids = tolist([aws_security_group.aft_vpc_default_sg.id])
+  dynamic "vpc_config" {
+    for_each = var.aft_feature_disable_private_networking ? {} : { k = "v" }
+    content {
+      subnet_ids         = tolist([aws_subnet.aft_vpc_private_subnet_01.id, aws_subnet.aft_vpc_private_subnet_02.id])
+      security_group_ids = tolist([aws_security_group.aft_vpc_default_sg.id])
+    }
   }
-
 }
 
 resource "time_sleep" "wait_60_seconds" {
@@ -60,9 +62,12 @@ resource "aws_lambda_function" "aft_account_request_action_trigger" {
   timeout          = "300"
   layers           = [var.aft_common_layer_arn]
 
-  vpc_config {
-    subnet_ids         = tolist([aws_subnet.aft_vpc_private_subnet_01.id, aws_subnet.aft_vpc_private_subnet_02.id])
-    security_group_ids = tolist([aws_security_group.aft_vpc_default_sg.id])
+  dynamic "vpc_config" {
+    for_each = var.aft_feature_disable_private_networking ? {} : { k = "v" }
+    content {
+      subnet_ids         = tolist([aws_subnet.aft_vpc_private_subnet_01.id, aws_subnet.aft_vpc_private_subnet_02.id])
+      security_group_ids = tolist([aws_security_group.aft_vpc_default_sg.id])
+    }
   }
 
 }
@@ -97,9 +102,12 @@ resource "aws_lambda_function" "aft_controltower_event_logger" {
   timeout          = "300"
   layers           = [var.aft_common_layer_arn]
 
-  vpc_config {
-    subnet_ids         = tolist([aws_subnet.aft_vpc_private_subnet_01.id, aws_subnet.aft_vpc_private_subnet_02.id])
-    security_group_ids = tolist([aws_security_group.aft_vpc_default_sg.id])
+  dynamic "vpc_config" {
+    for_each = var.aft_feature_disable_private_networking ? {} : { k = "v" }
+    content {
+      subnet_ids         = tolist([aws_subnet.aft_vpc_private_subnet_01.id, aws_subnet.aft_vpc_private_subnet_02.id])
+      security_group_ids = tolist([aws_security_group.aft_vpc_default_sg.id])
+    }
   }
 }
 
@@ -133,9 +141,12 @@ resource "aws_lambda_function" "aft_account_request_processor" {
   timeout          = "300"
   layers           = [var.aft_common_layer_arn]
 
-  vpc_config {
-    subnet_ids         = tolist([aws_subnet.aft_vpc_private_subnet_01.id, aws_subnet.aft_vpc_private_subnet_02.id])
-    security_group_ids = tolist([aws_security_group.aft_vpc_default_sg.id])
+  dynamic "vpc_config" {
+    for_each = var.aft_feature_disable_private_networking ? {} : { k = "v" }
+    content {
+      subnet_ids         = tolist([aws_subnet.aft_vpc_private_subnet_01.id, aws_subnet.aft_vpc_private_subnet_02.id])
+      security_group_ids = tolist([aws_security_group.aft_vpc_default_sg.id])
+    }
   }
 
 }
@@ -170,9 +181,12 @@ resource "aws_lambda_function" "aft_invoke_aft_account_provisioning_framework" {
   timeout          = "300"
   layers           = [var.aft_common_layer_arn]
 
-  vpc_config {
-    subnet_ids         = tolist([aws_subnet.aft_vpc_private_subnet_01.id, aws_subnet.aft_vpc_private_subnet_02.id])
-    security_group_ids = tolist([aws_security_group.aft_vpc_default_sg.id])
+  dynamic "vpc_config" {
+    for_each = var.aft_feature_disable_private_networking ? {} : { k = "v" }
+    content {
+      subnet_ids         = tolist([aws_subnet.aft_vpc_private_subnet_01.id, aws_subnet.aft_vpc_private_subnet_02.id])
+      security_group_ids = tolist([aws_security_group.aft_vpc_default_sg.id])
+    }
   }
 
 }

--- a/modules/aft-account-request-framework/locals.tf
+++ b/modules/aft-account-request-framework/locals.tf
@@ -3,4 +3,5 @@
 #
 locals {
   lambda_managed_policies = [data.aws_iam_policy.AWSLambdaBasicExecutionRole.arn, data.aws_iam_policy.AWSLambdaVPCAccessExecutionRole.arn]
+  vpc_endpoint_subnet_ids = var.aft_feature_disable_private_networking ? [aws_subnet.aft_vpc_public_subnet_01.id, aws_subnet.aft_vpc_public_subnet_02.id] : [aws_subnet.aft_vpc_private_subnet_01[0].id, aws_subnet.aft_vpc_private_subnet_02[0].id]
 }

--- a/modules/aft-account-request-framework/outputs.tf
+++ b/modules/aft-account-request-framework/outputs.tf
@@ -85,7 +85,7 @@ output "aft_vpc_public_subnets" {
 }
 
 output "aft_vpc_private_subnets" {
-  value = tolist([aws_subnet.aft_vpc_private_subnet_01.id, aws_subnet.aft_vpc_private_subnet_02.id])
+  value = tolist(var.aft_feature_disable_private_networking ? [] : [aws_subnet.aft_vpc_private_subnet_01[0].id, aws_subnet.aft_vpc_private_subnet_02[0].id])
 }
 
 output "aft_vpc_default_sg" {

--- a/modules/aft-account-request-framework/variables.tf
+++ b/modules/aft-account-request-framework/variables.tf
@@ -41,6 +41,10 @@ variable "aft_vpc_endpoints" {
   type = bool
 }
 
+variable "aft_feature_disable_private_networking" {
+  type = bool
+}
+
 variable "request_framework_archive_path" {
   type = string
 }

--- a/modules/aft-code-repositories/codebuild.tf
+++ b/modules/aft-code-repositories/codebuild.tf
@@ -48,10 +48,13 @@ resource "aws_codebuild_project" "account_request" {
     buildspec = data.local_file.account_request_buildspec.content
   }
 
-  vpc_config {
-    vpc_id             = var.vpc_id
-    subnets            = var.subnet_ids
-    security_group_ids = var.security_group_ids
+  dynamic "vpc_config" {
+    for_each = var.aft_feature_disable_private_networking ? {} : { k = "v" }
+    content {
+      vpc_id = var.vpc_id
+      subnets            = var.subnet_ids
+      security_group_ids = var.security_group_ids
+    }
   }
 
 }
@@ -97,10 +100,13 @@ resource "aws_codebuild_project" "account_provisioning_customizations_pipeline" 
     buildspec = data.local_file.account_provisioning_customizations_buildspec.content
   }
 
-  vpc_config {
-    vpc_id             = var.vpc_id
-    subnets            = var.subnet_ids
-    security_group_ids = var.security_group_ids
+  dynamic "vpc_config" {
+    for_each = var.aft_feature_disable_private_networking ? {} : { k = "v" }
+    content {
+      vpc_id = var.vpc_id
+      subnets            = var.subnet_ids
+      security_group_ids = var.security_group_ids
+    }
   }
 
 }

--- a/modules/aft-code-repositories/codestar.tf
+++ b/modules/aft-code-repositories/codestar.tf
@@ -25,9 +25,12 @@ resource "aws_codestarconnections_host" "githubenterprise" {
   provider_endpoint = var.github_enterprise_url
   provider_type     = "GitHubEnterpriseServer"
 
-  vpc_configuration {
-    security_group_ids = var.security_group_ids
-    subnet_ids         = var.subnet_ids
-    vpc_id             = var.vpc_id
+  dynamic "vpc_configuration" {
+    for_each = var.aft_feature_disable_private_networking ? {} : { k = "v" }
+    content {
+      security_group_ids = var.security_group_ids
+      subnet_ids         = var.subnet_ids
+      vpc_id             = var.vpc_id
+    }
   }
 }

--- a/modules/aft-code-repositories/variables.tf
+++ b/modules/aft-code-repositories/variables.tf
@@ -92,3 +92,7 @@ variable "account_provisioning_customizations_repo_branch" {
 variable "global_codebuild_timeout" {
   type = number
 }
+
+variable "aft_feature_disable_private_networking" {
+  type = bool
+}

--- a/modules/aft-customizations/codebuild.tf
+++ b/modules/aft-customizations/codebuild.tf
@@ -46,10 +46,13 @@ resource "aws_codebuild_project" "aft_global_customizations_terraform" {
     buildspec = data.local_file.aft_global_customizations_terraform.content
   }
 
-  vpc_config {
-    vpc_id             = var.aft_vpc_id
-    subnets            = var.aft_vpc_private_subnets
-    security_group_ids = var.aft_vpc_default_sg
+  dynamic "vpc_config" {
+    for_each = var.aft_feature_disable_private_networking ? {} : { k = "v" }
+    content {
+      vpc_id             = var.aft_vpc_id
+      subnets            = var.aft_vpc_private_subnets
+      security_group_ids = var.aft_vpc_default_sg
+    }
   }
 
 }
@@ -109,10 +112,13 @@ resource "aws_codebuild_project" "aft_account_customizations_terraform" {
     buildspec = data.local_file.aft_account_customizations_terraform.content
   }
 
-  vpc_config {
-    vpc_id             = var.aft_vpc_id
-    subnets            = var.aft_vpc_private_subnets
-    security_group_ids = var.aft_vpc_default_sg
+  dynamic "vpc_config" {
+    for_each = var.aft_feature_disable_private_networking ? {} : { k = "v" }
+    content {
+      vpc_id             = var.aft_vpc_id
+      subnets            = var.aft_vpc_private_subnets
+      security_group_ids = var.aft_vpc_default_sg
+    }
   }
 
 }
@@ -221,10 +227,13 @@ resource "aws_codebuild_project" "aft_create_pipeline" {
     buildspec = data.local_file.aft_create_pipeline.content
   }
 
-  vpc_config {
-    vpc_id             = var.aft_vpc_id
-    subnets            = var.aft_vpc_private_subnets
-    security_group_ids = var.aft_vpc_default_sg
+  dynamic "vpc_config" {
+    for_each = var.aft_feature_disable_private_networking ? {} : { k = "v" }
+    content {
+      vpc_id             = var.aft_vpc_id
+      subnets            = var.aft_vpc_private_subnets
+      security_group_ids = var.aft_vpc_default_sg
+    }
   }
 
 }

--- a/modules/aft-customizations/lambda.tf
+++ b/modules/aft-customizations/lambda.tf
@@ -17,9 +17,12 @@ resource "aws_lambda_function" "aft_customizations_identify_targets" {
   timeout          = "300"
   layers           = [var.aft_common_layer_arn]
 
-  vpc_config {
-    subnet_ids         = var.aft_vpc_private_subnets
-    security_group_ids = var.aft_vpc_default_sg
+  dynamic "vpc_config" {
+    for_each = var.aft_feature_disable_private_networking ? {} : { k = "v" }
+    content {
+      subnet_ids         = var.aft_vpc_private_subnets
+      security_group_ids = var.aft_vpc_default_sg
+    }
   }
 }
 
@@ -43,9 +46,12 @@ resource "aws_lambda_function" "aft_customizations_execute_pipeline" {
   timeout          = "300"
   layers           = [var.aft_common_layer_arn]
 
-  vpc_config {
-    subnet_ids         = var.aft_vpc_private_subnets
-    security_group_ids = var.aft_vpc_default_sg
+  dynamic "vpc_config" {
+    for_each = var.aft_feature_disable_private_networking ? {} : { k = "v" }
+    content {
+      subnet_ids         = var.aft_vpc_private_subnets
+      security_group_ids = var.aft_vpc_default_sg
+    }
   }
 }
 
@@ -68,9 +74,12 @@ resource "aws_lambda_function" "aft_customizations_get_pipeline_executions" {
   timeout          = "300"
   layers           = [var.aft_common_layer_arn]
 
-  vpc_config {
-    subnet_ids         = var.aft_vpc_private_subnets
-    security_group_ids = var.aft_vpc_default_sg
+  dynamic "vpc_config" {
+    for_each = var.aft_feature_disable_private_networking ? {} : { k = "v" }
+    content {
+      subnet_ids         = var.aft_vpc_private_subnets
+      security_group_ids = var.aft_vpc_default_sg
+    }
   }
 
 }

--- a/modules/aft-customizations/variables.tf
+++ b/modules/aft-customizations/variables.tf
@@ -108,3 +108,7 @@ variable "customizations_archive_hash" {
 variable "global_codebuild_timeout" {
   type = number
 }
+
+variable "aft_feature_disable_private_networking" {
+  type = bool
+}

--- a/modules/aft-feature-options/lambda.tf
+++ b/modules/aft-feature-options/lambda.tf
@@ -16,9 +16,12 @@ resource "aws_lambda_function" "aft_delete_default_vpc" {
   timeout          = "300"
   layers           = [var.aft_common_layer_arn]
 
-  vpc_config {
-    subnet_ids         = var.aft_vpc_private_subnets
-    security_group_ids = var.aft_vpc_default_sg
+  dynamic "vpc_config" {
+    for_each = var.aft_feature_disable_private_networking ? {} : { k = "v" }
+    content {
+      subnet_ids         = var.aft_vpc_private_subnets
+      security_group_ids = var.aft_vpc_default_sg
+    }
   }
 }
 
@@ -44,9 +47,12 @@ resource "aws_lambda_function" "aft_enroll_support" {
   timeout          = "300"
   layers           = [var.aft_common_layer_arn]
 
-  vpc_config {
-    subnet_ids         = var.aft_vpc_private_subnets
-    security_group_ids = var.aft_vpc_default_sg
+  dynamic "vpc_config" {
+    for_each = var.aft_feature_disable_private_networking ? {} : { k = "v" }
+    content {
+      subnet_ids         = var.aft_vpc_private_subnets
+      security_group_ids = var.aft_vpc_default_sg
+    }
   }
 }
 
@@ -71,9 +77,12 @@ resource "aws_lambda_function" "aft_enable_cloudtrail" {
   timeout          = "300"
   layers           = [var.aft_common_layer_arn]
 
-  vpc_config {
-    subnet_ids         = var.aft_vpc_private_subnets
-    security_group_ids = var.aft_vpc_default_sg
+  dynamic "vpc_config" {
+    for_each = var.aft_feature_disable_private_networking ? {} : { k = "v" }
+    content {
+      subnet_ids         = var.aft_vpc_private_subnets
+      security_group_ids = var.aft_vpc_default_sg
+    }
   }
 }
 

--- a/modules/aft-feature-options/locals.tf
+++ b/modules/aft-feature-options/locals.tf
@@ -3,4 +3,5 @@
 #
 locals {
   lambda_managed_policies = [data.aws_iam_policy.AWSLambdaBasicExecutionRole.arn, data.aws_iam_policy.AWSLambdaVPCAccessExecutionRole.arn]
+  lambda_subnet_ids       =  var.aft_feature_disable_private_networking ? var.aft_vpc_public_subnets : var.aft_vpc_private_subnets
 }

--- a/modules/aft-feature-options/variables.tf
+++ b/modules/aft-feature-options/variables.tf
@@ -5,6 +5,10 @@ variable "aft_vpc_private_subnets" {
   type = list(string)
 }
 
+variable "aft_vpc_public_subnets" {
+  type = list(string)
+}
+
 variable "aft_vpc_default_sg" {
   type = list(string)
 }
@@ -54,4 +58,8 @@ variable "feature_options_archive_path" {
 
 variable "feature_options_archive_hash" {
   type = string
+}
+
+variable "aft_feature_disable_private_networking" {
+  type = bool
 }

--- a/modules/aft-lambda-layer/codebuild.tf
+++ b/modules/aft-lambda-layer/codebuild.tf
@@ -74,10 +74,12 @@ resource "aws_codebuild_project" "codebuild" {
     buildspec = data.local_file.aft_lambda_layer.content
   }
 
-  vpc_config {
-    vpc_id             = var.aft_vpc_id
-    subnets            = var.aft_vpc_private_subnets
-    security_group_ids = var.aft_vpc_default_sg
+  dynamic "vpc_config" {
+    for_each = var.aft_feature_disable_private_networking ? {} : { k = "v" }
+    content {
+      vpc_id             = var.aft_vpc_id
+      subnets            = var.aft_vpc_private_subnets
+      security_group_ids = var.aft_vpc_default_sg
+    }
   }
-
 }

--- a/modules/aft-lambda-layer/lambda.tf
+++ b/modules/aft-lambda-layer/lambda.tf
@@ -12,9 +12,12 @@ resource "aws_lambda_function" "codebuild_invoker" {
   runtime          = "python3.8"
   timeout          = 900
 
-  vpc_config {
-    subnet_ids         = var.aft_vpc_private_subnets
-    security_group_ids = var.aft_vpc_default_sg
+  dynamic "vpc_config" {
+    for_each = var.aft_feature_disable_private_networking ? {} : { k = "v" }
+    content {
+      subnet_ids         = var.aft_vpc_private_subnets
+      security_group_ids = var.aft_vpc_default_sg
+    }
   }
 }
 

--- a/modules/aft-lambda-layer/locals.tf
+++ b/modules/aft-lambda-layer/locals.tf
@@ -6,4 +6,6 @@ locals {
   account_id                      = data.aws_caller_identity.session.account_id
   target_id                       = "trigger_build"
   codebuild_invoker_function_name = "aft-lambda-layer-codebuild-invoker"
+  codebuild_subnet_ids            =  var.aft_feature_disable_private_networking ? var.aft_vpc_public_subnets : var.aft_vpc_private_subnets
+  lambda_subnet_ids               =  var.aft_feature_disable_private_networking ? var.aft_vpc_public_subnets : var.aft_vpc_private_subnets
 }

--- a/modules/aft-lambda-layer/variables.tf
+++ b/modules/aft-lambda-layer/variables.tf
@@ -45,6 +45,10 @@ variable "aft_vpc_private_subnets" {
   type = list(string)
 }
 
+variable "aft_vpc_public_subnets" {
+  type = list(string)
+}
+
 variable "aft_vpc_default_sg" {
   type = list(string)
 }
@@ -58,4 +62,8 @@ variable "builder_archive_path" {
 
 variable "builder_archive_hash" {
   type = string
+}
+
+variable "aft_feature_disable_private_networking" {
+  type = bool
 }

--- a/variables.tf
+++ b/variables.tf
@@ -143,6 +143,16 @@ variable "aft_feature_delete_default_vpcs_enabled" {
   }
 }
 
+variable "aft_feature_disable_private_networking" {
+  description = "Feature flag toggling disabling private networking on/off"
+  type        = bool
+  default     = false
+  validation {
+    condition     = contains([true, false], var.aft_feature_disable_private_networking)
+    error_message = "Valid values for var: aft_feature_disable_private_networking are (true, false)."
+  }
+}
+
 #########################################
 # AFT Customer VCS Variables
 #########################################


### PR DESCRIPTION
Understandable you are not accepting contribution at this point, please find attached PR for when you decide to save your customers cost regarding natgw.

feat: add opt-in feature flag `aft_feature_disable_private_networking` to disable private networking infrastructure

- run lambdas outside of vpc
- run codebuild outside of vpc
- run codestar outside of vpc
- remove natgw and private subnets
- sparse formatting

# Contributing to the AWS Control Tower Account Factory for Terraform

Thank you for your interest in contributing to the AWS Control Tower Account Factory for Terraform.

At this time, we are not accepting contributions. If contributions are accepted in the future, the AWS Control Tower Account Factory for Terraform is released under the [Apache license](http://aws.amazon.com/apache2.0/) and any code submitted will be released under that license.

If you have a feature request, please create an issue using the Feature Request template, thanks!
