### PR TITLE
Set aft_controltower_backup_rule to expire after 10 days

### DIFF
--- a/modules/aft-account-request-framework/backup.tf
+++ b/modules/aft-account-request-framework/backup.tf
@@ -11,6 +11,10 @@ resource "aws_backup_plan" "aft_controltower_backup_plan" {
     rule_name         = "aft_controltower_backup_rule"
     target_vault_name = aws_backup_vault.aft_controltower_backup_vault.name
     schedule          = "cron(0 * * * ? *)"
+
+    lifecycle { 
+      delete_after = 10
+    }
   }
 }
 


### PR DESCRIPTION
This fixes bug https://github.com/aws-ia/terraform-aws-control_tower_account_factory/issues/295

We do not expect you to accept this PR, this is just an example of how to fix the bug above, it's a simple fix to address this problem. 