### PR TITLE
fix: Add missing provider meta-args for data.aws_partition

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -5,4 +5,6 @@ data "local_file" "version" {
   filename = "${path.module}/VERSION"
 }
 
-data "aws_partition" "current" {}
+data "aws_partition" "current" {
+  provider = aws.ct_management
+}

--- a/modules/aft-feature-options/data.tf
+++ b/modules/aft-feature-options/data.tf
@@ -1,7 +1,9 @@
 # Copyright Amazon.com, Inc. or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-data "aws_partition" "current" {}
+data "aws_partition" "current" {
+  provider = aws.aft_management
+}
 
 data "aws_region" "current" {
   provider = aws.aft_management

--- a/modules/aft-iam-roles/data.tf
+++ b/modules/aft-iam-roles/data.tf
@@ -5,4 +5,6 @@ data "aws_caller_identity" "aft_management" {
   provider = aws.aft_management
 }
 
-data "aws_partition" "current" {}
+data "aws_partition" "current" {
+  provider = aws.aft_management
+}


### PR DESCRIPTION
Appreciate you aren't accepting PRs directly, but this demonstrates a simple fix for the issue described in #232.