### PR TITLE
Updated pyproject.toml for CVEs:

### DIFF
--- a/sources/aft-lambda-layer/pyproject.toml
+++ b/sources/aft-lambda-layer/pyproject.toml
@@ -3,7 +3,7 @@
 
 [build-system]
 requires = [
-    "setuptools",
+    "setuptools == 70.0.0",
     "wheel",
 ]
 
@@ -26,7 +26,7 @@ classifiers=[
 dependencies = [
     "boto3 == 1.28.17",
     "botocore == 1.31.17",
-    "requests == 2.31.0",
+    "requests == 2.32.2",
     "jsonschema == 4.3.2",
 ]
 


### PR DESCRIPTION
- [CVE-2022-40897](https://nvd.nist.gov/vuln/detail/CVE-2022-40897)
- [CVE-2024-35195](https://nvd.nist.gov/vuln/detail/CVE-2024-35195)
- [CVE-2024-6345](https://nvd.nist.gov/vuln/detail/CVE-2024-6345)

# Contributing to the AWS Control Tower Account Factory for Terraform

Thank you for your interest in contributing to the AWS Control Tower Account Factory for Terraform.

At this time, we are not accepting contributions. If contributions are accepted in the future, the AWS Control Tower Account Factory for Terraform is released under the [Apache license](http://aws.amazon.com/apache2.0/) and any code submitted will be released under that license.

If you have a feature request, please create an issue using the Feature Request template, thanks!
