### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-@balltrev @adam-daily @hanafya @tonynv @andrew-glenn @stumins @snebhu3 @aws-ia/aws-ia
+@balltrev @adam-daily @hanafya @tonynv @andrew-glenn @stumins @snebhu3 @aws-ia/internal-aws-control-tower-team

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-@balltrev @adam-daily @hanafya @tonynv @andrew-glenn @stumins @snebhu3 @aws-ia/internal-aws-control-tower-team
+@balltrev @adam-daily @hanafya @tonynv @andrew-glenn @snebhu3 @aws-ia/internal-aws-control-tower-team


### PR DESCRIPTION
# Contributing to the AWS Control Tower Account Factory for Terraform

Thank you for your interest in contributing to the AWS Control Tower Account Factory for Terraform.

At this time, we are not accepting contributions. If contributions are accepted in the future, the AWS Control Tower Account Factory for Terraform is released under the [Apache license](http://aws.amazon.com/apache2.0/) and any code submitted will be released under that license.

If you have a feature request, please create an issue using the Feature Request template, thanks!
