### PR TITLE
✨ Added support for GitLab as vcs_provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ As of version 1.6.0, AFT collects anonymous operational metrics to help AWS impr
 | <a name="input_terraform_token"></a> [terraform\_token](#input\_terraform\_token) | Terraform token for Cloud or Enterprise | `string` | `"null"` | no |
 | <a name="input_terraform_version"></a> [terraform\_version](#input\_terraform\_version) | Terraform version being used for AFT | `string` | `"1.6.0"` | no |
 | <a name="input_tf_backend_secondary_region"></a> [tf\_backend\_secondary\_region](#input\_tf\_backend\_secondary\_region) | AFT creates a backend for state tracking for its own state as well as OSS cases. The backend's primary region is the same as the AFT region, but this defines the secondary region to replicate to. | `string` | `""` | no |
-| <a name="input_vcs_provider"></a> [vcs\_provider](#input\_vcs\_provider) | Customer VCS Provider - valid inputs are codecommit, bitbucket, github, githubenterprise, or gitlab | `string` | `"codecommit"` | no |
+| <a name="input_vcs_provider"></a> [vcs\_provider](#input\_vcs\_provider) | Customer VCS Provider - valid inputs are codecommit, bitbucket, github, githubenterprise, gitlab, or gitlabselfmanaged | `string` | `"codecommit"` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ As of version 1.6.0, AFT collects anonymous operational metrics to help AWS impr
 | <a name="input_terraform_token"></a> [terraform\_token](#input\_terraform\_token) | Terraform token for Cloud or Enterprise | `string` | `"null"` | no |
 | <a name="input_terraform_version"></a> [terraform\_version](#input\_terraform\_version) | Terraform version being used for AFT | `string` | `"1.6.0"` | no |
 | <a name="input_tf_backend_secondary_region"></a> [tf\_backend\_secondary\_region](#input\_tf\_backend\_secondary\_region) | AFT creates a backend for state tracking for its own state as well as OSS cases. The backend's primary region is the same as the AFT region, but this defines the secondary region to replicate to. | `string` | `""` | no |
-| <a name="input_vcs_provider"></a> [vcs\_provider](#input\_vcs\_provider) | Customer VCS Provider - valid inputs are codecommit, bitbucket, github, or githubenterprise | `string` | `"codecommit"` | no |
+| <a name="input_vcs_provider"></a> [vcs\_provider](#input\_vcs\_provider) | Customer VCS Provider - valid inputs are codecommit, bitbucket, github, githubenterprise, or gitlab | `string` | `"codecommit"` | no |
 
 ## Outputs
 

--- a/examples/gitlab+tf_oss/main.tf
+++ b/examples/gitlab+tf_oss/main.tf
@@ -1,0 +1,19 @@
+# Copyright Amazon.com, Inc. or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+module "aft" {
+  source = "github.com/aws-ia/terraform-aws-control_tower_account_factory"
+  # Required Vars
+  ct_management_account_id    = "111122223333"
+  log_archive_account_id      = "444455556666"
+  audit_account_id            = "123456789012"
+  aft_management_account_id   = "777788889999"
+  ct_home_region              = "us-east-1"
+  tf_backend_secondary_region = "us-west-2"
+  # VCS Vars
+  vcs_provider                                  = "gitlab"
+  account_request_repo_name                     = "ExampleOrg/example-repo-1"
+  global_customizations_repo_name               = "ExampleOrg/example-repo-2"
+  account_customizations_repo_name              = "ExampleOrg/example-repo-3"
+  account_provisioning_customizations_repo_name = "ExampleOrg/example-repo-4"
+}

--- a/examples/gitlabselfmanaged+tf_cloud/main.tf
+++ b/examples/gitlabselfmanaged+tf_cloud/main.tf
@@ -11,9 +11,14 @@ module "aft" {
   ct_home_region              = "us-east-1"
   tf_backend_secondary_region = "us-west-2"
   # VCS Vars
-  vcs_provider                                  = "gitlab"
+  vcs_provider                                  = "gitlabselfmanaged"
+  gitlab_selfmanaged_url                        = "https://gitlab.example.com"
   account_request_repo_name                     = "ExampleProject/example-repo-1"
   global_customizations_repo_name               = "ExampleProject/example-repo-2"
   account_customizations_repo_name              = "ExampleProject/example-repo-3"
   account_provisioning_customizations_repo_name = "ExampleProject/example-repo-4"
+  # TF Vars
+  terraform_distribution = "tfc"
+  terraform_token        = "EXAMPLE-uoc1c1qsw7poexampleewjeno1pte3rw"
+  terraform_org_name     = "ExampleOrg"
 }

--- a/main.tf
+++ b/main.tf
@@ -92,6 +92,7 @@ module "aft_code_repositories" {
   account_customizations_repo_name                = var.account_customizations_repo_name
   global_customizations_repo_name                 = var.global_customizations_repo_name
   github_enterprise_url                           = var.github_enterprise_url
+  gitlab_selfmanaged_url                          = var.gitlab_selfmanaged_url
   vcs_provider                                    = var.vcs_provider
   terraform_distribution                          = var.terraform_distribution
   account_provisioning_customizations_repo_name   = var.account_provisioning_customizations_repo_name
@@ -269,5 +270,6 @@ module "aft_ssm_parameters" {
   account_provisioning_customizations_repo_branch             = var.account_provisioning_customizations_repo_branch
   maximum_concurrent_customizations                           = var.maximum_concurrent_customizations
   github_enterprise_url                                       = var.github_enterprise_url
+  gitlab_selfmanaged_url                                      = var.gitlab_selfmanaged_url
   aft_metrics_reporting                                       = var.aft_metrics_reporting
 }

--- a/modules/aft-code-repositories/codepipeline.tf
+++ b/modules/aft-code-repositories/codepipeline.tf
@@ -140,7 +140,7 @@ resource "aws_codepipeline" "codestar_account_request" {
       output_artifacts = ["account-request"]
 
       configuration = {
-        ConnectionArn        = lookup({ github = local.connection_arn.github, bitbucket = local.connection_arn.bitbucket, githubenterprise = local.connection_arn.githubenterprise }, var.vcs_provider)
+        ConnectionArn        = lookup({ github = local.connection_arn.github, bitbucket = local.connection_arn.bitbucket, githubenterprise = local.connection_arn.githubenterprise, gitlab = local.connection_arn.gitlab }, var.vcs_provider)
         FullRepositoryId     = var.account_request_repo_name
         BranchName           = var.account_request_repo_branch
         DetectChanges        = true

--- a/modules/aft-code-repositories/codepipeline.tf
+++ b/modules/aft-code-repositories/codepipeline.tf
@@ -140,7 +140,7 @@ resource "aws_codepipeline" "codestar_account_request" {
       output_artifacts = ["account-request"]
 
       configuration = {
-        ConnectionArn        = lookup({ github = local.connection_arn.github, bitbucket = local.connection_arn.bitbucket, githubenterprise = local.connection_arn.githubenterprise, gitlab = local.connection_arn.gitlab }, var.vcs_provider)
+        ConnectionArn        = lookup({ github = local.connection_arn.github, bitbucket = local.connection_arn.bitbucket, githubenterprise = local.connection_arn.githubenterprise, gitlab = local.connection_arn.gitlab, gitlabselfmanaged = local.connection_arn.gitlabselfmanaged }, var.vcs_provider)
         FullRepositoryId     = var.account_request_repo_name
         BranchName           = var.account_request_repo_branch
         DetectChanges        = true
@@ -271,7 +271,7 @@ resource "aws_codepipeline" "codestar_account_provisioning_customizations" {
       output_artifacts = ["account-provisioning-customizations"]
 
       configuration = {
-        ConnectionArn        = lookup({ github = local.connection_arn.github, bitbucket = local.connection_arn.bitbucket, githubenterprise = local.connection_arn.githubenterprise }, var.vcs_provider)
+        ConnectionArn        = lookup({ github = local.connection_arn.github, bitbucket = local.connection_arn.bitbucket, githubenterprise = local.connection_arn.githubenterprise, gitlab = local.connection_arn.gitlab, gitlabselfmanaged = local.connection_arn.gitlabselfmanaged }, var.vcs_provider)
         FullRepositoryId     = var.account_provisioning_customizations_repo_name
         BranchName           = var.account_provisioning_customizations_repo_branch
         DetectChanges        = true

--- a/modules/aft-code-repositories/codestar.tf
+++ b/modules/aft-code-repositories/codestar.tf
@@ -40,3 +40,25 @@ resource "aws_codestarconnections_connection" "gitlab" {
   name          = "ct-aft-gitlab-connection"
   provider_type = "GitLab"
 }
+
+resource "aws_codestarconnections_connection" "gitlabselfmanaged" {
+  count    = local.vcs.is_gitlab_selfmanaged ? 1 : 0
+  name     = "ct-aft-gitlab-selfmanaged-connection"
+  host_arn = aws_codestarconnections_host.gitlabselfmanaged[0].arn
+}
+
+resource "aws_codestarconnections_host" "gitlabselfmanaged" {
+  count             = local.vcs.is_gitlab_selfmanaged ? 1 : 0
+  name              = "gitlab-selfmanaged-host"
+  provider_endpoint = var.gitlab_selfmanaged_url
+  provider_type     = "GitLabSelfManaged"
+
+  dynamic "vpc_configuration" {
+    for_each = var.aft_enable_vpc ? [1] : []
+    content {
+      security_group_ids = var.security_group_ids
+      subnet_ids         = var.subnet_ids
+      vpc_id             = var.vpc_id
+    }
+  }
+}

--- a/modules/aft-code-repositories/codestar.tf
+++ b/modules/aft-code-repositories/codestar.tf
@@ -43,7 +43,7 @@ resource "aws_codestarconnections_connection" "gitlab" {
 
 resource "aws_codestarconnections_connection" "gitlabselfmanaged" {
   count    = local.vcs.is_gitlab_selfmanaged ? 1 : 0
-  name     = "ct-aft-gitlab-selfmanaged-connection"
+  name     = "ct-aft-gitlab-sm-connection"
   host_arn = aws_codestarconnections_host.gitlabselfmanaged[0].arn
 }
 

--- a/modules/aft-code-repositories/codestar.tf
+++ b/modules/aft-code-repositories/codestar.tf
@@ -34,3 +34,9 @@ resource "aws_codestarconnections_host" "githubenterprise" {
     }
   }
 }
+
+resource "aws_codestarconnections_connection" "gitlab" {
+  count         = local.vcs.is_gitlab ? 1 : 0
+  name          = "ct-aft-gitlab-connection"
+  provider_type = "GitLab"
+}

--- a/modules/aft-code-repositories/locals.tf
+++ b/modules/aft-code-repositories/locals.tf
@@ -3,17 +3,20 @@
 #
 locals {
   vcs = {
-    is_codecommit        = lower(var.vcs_provider) == "codecommit" ? true : false
-    is_bitbucket         = lower(var.vcs_provider) == "bitbucket" ? true : false
-    is_github            = lower(var.vcs_provider) == "github" ? true : false
-    is_github_enterprise = lower(var.vcs_provider) == "githubenterprise" ? true : false
-    is_gitlab            = lower(var.vcs_provider) == "gitlab" ? true : false
+    is_codecommit         = lower(var.vcs_provider) == "codecommit" ? true : false
+    is_bitbucket          = lower(var.vcs_provider) == "bitbucket" ? true : false
+    is_github             = lower(var.vcs_provider) == "github" ? true : false
+    is_github_enterprise  = lower(var.vcs_provider) == "githubenterprise" ? true : false
+    is_gitlab             = lower(var.vcs_provider) == "gitlab" ? true : false
+    is_gitlab_selfmanaged = lower(var.vcs_provider) == "gitlabselfmanaged" ? true : false
   }
   connection_arn = {
-    bitbucket        = lower(var.vcs_provider) == "bitbucket" ? aws_codestarconnections_connection.bitbucket[0].arn : ""
-    github           = lower(var.vcs_provider) == "github" ? aws_codestarconnections_connection.github[0].arn : ""
-    githubenterprise = lower(var.vcs_provider) == "githubenterprise" ? aws_codestarconnections_connection.githubenterprise[0].arn : ""
-    gitlab           = lower(var.vcs_provider) == "gitlab" ? aws_codestarconnections_connection.gitlab[0].arn : ""
-    codecommit       = "null"
+    bitbucket         = lower(var.vcs_provider) == "bitbucket" ? aws_codestarconnections_connection.bitbucket[0].arn : ""
+    github            = lower(var.vcs_provider) == "github" ? aws_codestarconnections_connection.github[0].arn : ""
+    githubenterprise  = lower(var.vcs_provider) == "githubenterprise" ? aws_codestarconnections_connection.githubenterprise[0].arn : ""
+    gitlab            = lower(var.vcs_provider) == "gitlab" ? aws_codestarconnections_connection.gitlab[0].arn : ""
+    gitlabselfmanaged = lower(var.vcs_provider) == "gitlabselfmanaged" ? aws_codestarconnections_connection.gitlabselfmanaged[0].arn : ""
+    codecommit        = "null"
   }
 }
+

--- a/modules/aft-code-repositories/locals.tf
+++ b/modules/aft-code-repositories/locals.tf
@@ -7,11 +7,13 @@ locals {
     is_bitbucket         = lower(var.vcs_provider) == "bitbucket" ? true : false
     is_github            = lower(var.vcs_provider) == "github" ? true : false
     is_github_enterprise = lower(var.vcs_provider) == "githubenterprise" ? true : false
+    is_gitlab            = lower(var.vcs_provider) == "gitlab" ? true : false
   }
   connection_arn = {
     bitbucket        = lower(var.vcs_provider) == "bitbucket" ? aws_codestarconnections_connection.bitbucket[0].arn : ""
     github           = lower(var.vcs_provider) == "github" ? aws_codestarconnections_connection.github[0].arn : ""
     githubenterprise = lower(var.vcs_provider) == "githubenterprise" ? aws_codestarconnections_connection.githubenterprise[0].arn : ""
+    gitlab           = lower(var.vcs_provider) == "gitlab" ? aws_codestarconnections_connection.gitlab[0].arn : ""
     codecommit       = "null"
   }
 }

--- a/modules/aft-code-repositories/variables.tf
+++ b/modules/aft-code-repositories/variables.tf
@@ -30,6 +30,10 @@ variable "github_enterprise_url" {
   type = string
 }
 
+variable "gitlab_selfmanaged_url" {
+  type = string
+}
+
 variable "account_request_table_name" {
   type = string
 }

--- a/modules/aft-ssm-parameters/ssm.tf
+++ b/modules/aft-ssm-parameters/ssm.tf
@@ -346,6 +346,13 @@ resource "aws_ssm_parameter" "github_enterprise_url" {
   value = var.github_enterprise_url
 }
 
+resource "aws_ssm_parameter" "gitlab_selfmanaged_url" {
+  name  = "/aft/config/vcs/gitlab-selfmanaged-url"
+  type  = "String"
+  value = var.gitlab_selfmanaged_url
+}
+
+
 resource "aws_ssm_parameter" "aft_logging_bucket_arn" {
   name  = "/aft/account/log-archive/log_bucket_arn"
   type  = "String"

--- a/modules/aft-ssm-parameters/variables.tf
+++ b/modules/aft-ssm-parameters/variables.tf
@@ -230,6 +230,10 @@ variable "github_enterprise_url" {
   type = string
 }
 
+variable "gitlab_selfmanaged_url" {
+  type = string
+}
+
 variable "aft_logging_bucket_arn" {
   type = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -192,13 +192,19 @@ variable "vcs_provider" {
   type        = string
   default     = "codecommit"
   validation {
-    condition     = contains(["codecommit", "bitbucket", "github", "githubenterprise", "gitlab"], var.vcs_provider)
-    error_message = "Valid values for var: vcs_provider are (codecommit, bitbucket, github, githubenterprise, gitlab)."
+    condition     = contains(["codecommit", "bitbucket", "github", "githubenterprise", "gitlab", "gitlabselfmanaged"], var.vcs_provider)
+    error_message = "Valid values for var: vcs_provider are (codecommit, bitbucket, github, githubenterprise, gitlab, gitlabselfmanaged)."
   }
 }
 
 variable "github_enterprise_url" {
   description = "GitHub enterprise URL, if GitHub Enterprise is being used"
+  type        = string
+  default     = "null"
+}
+
+variable "gitlab_selfmanaged_url" {
+  description = "GitLab SelfManaged URL, if GitLab SelfManaged is being used"
   type        = string
   default     = "null"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -192,8 +192,8 @@ variable "vcs_provider" {
   type        = string
   default     = "codecommit"
   validation {
-    condition     = contains(["codecommit", "bitbucket", "github", "githubenterprise"], var.vcs_provider)
-    error_message = "Valid values for var: vcs_provider are (codecommit, bitbucket, github, githubenterprise)."
+    condition     = contains(["codecommit", "bitbucket", "github", "githubenterprise", "gitlab"], var.vcs_provider)
+    error_message = "Valid values for var: vcs_provider are (codecommit, bitbucket, github, githubenterprise, gitlab)."
   }
 }
 


### PR DESCRIPTION
# Overview
This PR introduces support for GitLab and GitLab Self-Hosted as options for the vcs_provider in Control Tower. This enhancement allows users to integrate their GitLab repositories, both cloud-hosted and self-hosted, with Control Tower, expanding the flexibility and usability of the tool.

## Changes
- Added support for Gitlab as vcs_provider
- Added support for Self Hosted Gitlab instance as vcs_provider
- Updated README & Examples

## Testing
Tested successfully by Sriram