### PR TITLE
Allow default tags to be set using a variable

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -6,9 +6,7 @@ provider "aws" {
   region = var.ct_home_region
   # The default profile or environment variables should authenticate to the Control Tower Management Account as Administrator
   default_tags {
-    tags = {
-      managed_by = "AFT"
-    }
+    tags = var.default_tags
   }
 }
 
@@ -20,9 +18,7 @@ provider "aws" {
     session_name = local.aft_session_name
   }
   default_tags {
-    tags = {
-      managed_by = "AFT"
-    }
+    tags = var.default_tags
   }
 }
 provider "aws" {
@@ -33,9 +29,7 @@ provider "aws" {
     session_name = local.aft_session_name
   }
   default_tags {
-    tags = {
-      managed_by = "AFT"
-    }
+    tags = var.default_tags
   }
 }
 provider "aws" {
@@ -46,9 +40,7 @@ provider "aws" {
     session_name = local.aft_session_name
   }
   default_tags {
-    tags = {
-      managed_by = "AFT"
-    }
+    tags = var.default_tags
   }
 }
 provider "aws" {
@@ -59,8 +51,6 @@ provider "aws" {
     session_name = local.aft_session_name
   }
   default_tags {
-    tags = {
-      managed_by = "AFT"
-    }
+    tags = var.default_tags
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -149,6 +149,14 @@ variable "global_codebuild_timeout" {
   }
 }
 
+variable "default_tags" {
+  type        = map(string)
+  description = "Tags to apply to all supported resources"
+  default = {
+    managed_by = "AFT"
+  }
+}
+
 #########################################
 # AFT Feature Flags
 #########################################


### PR DESCRIPTION
In our organisation, we require a set of tags to be set on all resources. It currently isn't possible to do that on AFT created resources, and this PR allows that.

#466 (which superseeds #23) suggests merging customer defined tags with the default `managed_by` tag currently set on all providers. This is less than ideal for our use case, as we don't want to have that tag. We actually require a `MANAGED_BY` tag (all-caps).

Ideally we would be able to define the providers ourselves, but that would be a breaking change. If you are interested, I would be happy to implement that. This would allow us to have different sets of tags on each provider, which we would like, in order to have a different `ACCOUNT_ID` tag
