### PR TITLE
AWS EIP Terraform Update

### DIFF
--- a/modules/aft-account-request-framework/vpc.tf
+++ b/modules/aft-account-request-framework/vpc.tf
@@ -203,12 +203,12 @@ resource "aws_internet_gateway" "aft-vpc-igw" {
 
 resource "aws_eip" "aft-vpc-natgw-01" {
   count = var.aft_enable_vpc ? 1 : 0
-  vpc   = true
+  domain = "vpc"
 }
 
 resource "aws_eip" "aft-vpc-natgw-02" {
   count = var.aft_enable_vpc ? 1 : 0
-  vpc   = true
+  domain = "vpc"
 }
 
 resource "aws_nat_gateway" "aft-vpc-natgw-01" {


### PR DESCRIPTION
# Contributing to the AWS Control Tower Account Factory for Terraform

Updated from deprecated call 'vpc = true' to 'domain = vpc'
