### PR TITLE
Updated role_arn to fix deprecation warning

### DIFF
--- a/sources/aft-customizations-repos/aft-account-customizations/ACCOUNT_TEMPLATE/terraform/backend.jinja
+++ b/sources/aft-customizations-repos/aft-account-customizations/ACCOUNT_TEMPLATE/terraform/backend.jinja
@@ -11,7 +11,9 @@ terraform {
     dynamodb_table = "{{ dynamodb_table }}"
     encrypt        = "true"
     kms_key_id     = "{{ kms_key_id }}"
-    role_arn       = "{{ aft_admin_role_arn }}"
+    assume_role {
+      role_arn    = "{{ aft_admin_role_arn }}"
+    }
   }
 }
 {% else -%}


### PR DESCRIPTION
Understanding that no PRs are being taken - submitting this as a feature request to fix deprecation warning in pipelines.

Error is as follows:
```base
Warning: Deprecated Parameters

The following parameters have been deprecated. Replace them as follows:
     * role_arn -> assume_role.role_arn
```



Default response
```
# Contributing to the AWS Control Tower Account Factory for Terraform

Thank you for your interest in contributing to the AWS Control Tower Account Factory for Terraform.

At this time, we are not accepting contributions. If contributions are accepted in the future, the AWS Control Tower Account Factory for Terraform is released under the [Apache license](http://aws.amazon.com/apache2.0/) and any code submitted will be released under that license.

If you have a feature request, please create an issue using the Feature Request template, thanks!
```