### PR TITLE
add source code hash to lambda layer

### DIFF
--- a/modules/aft-lambda-layer/data.tf
+++ b/modules/aft-lambda-layer/data.tf
@@ -8,3 +8,8 @@ data "aws_caller_identity" "session" {}
 data "local_file" "aft_lambda_layer" {
   filename = "${path.module}/buildspecs/aft-lambda-layer.yml"
 }
+
+data "aws_s3_bucket_object" "aft_lambda_layer" {
+  bucket = var.s3_bucket_name
+  key    = "layer.zip"
+}

--- a/modules/aft-lambda-layer/main.tf
+++ b/modules/aft-lambda-layer/main.tf
@@ -20,4 +20,5 @@ resource "aws_lambda_layer_version" "layer_version" {
   compatible_runtimes = ["python${var.lambda_layer_python_version}"]
   s3_bucket           = var.s3_bucket_name
   s3_key              = "layer.zip"
+  source_code_hash    = data.aws_s3_bucket_object.aft_lambda_layer.etag
 }


### PR DESCRIPTION
# AFT Version
1.13.2

# Open issue
https://github.com/aws-ia/terraform-aws-control_tower_account_factory/issues/507

# Description
I implemented AFT a few months ago when it was not yet compatible with GitLab. Recently, I noticed that starting with version 1.13.2, the module now supports GitLab integration.

While updating the AFT module to use GitLab, I encountered the same issue: when files in the bucket aft-customizations-pipeline-your_account_id were updated, Terraform did not detect the changes to generate a new layer version. This caused a mismatch between the bucket and the code used by the layer.

The solution I implemented was to add the source_code_hash attribute to the aws_lambda_layer_version resource, setting it to use the etag attribute from the aws_s3_bucket_object data source. This ensures that whenever the object in the bucket is updated, Terraform detects the change and automatically publishes a new layer version.

# Reference links
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_layer_version#source_code_hash-1
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object#etag-1




