### PR TITLE
Use equals in assume_role example

### DIFF
--- a/sources/aft-customizations-repos/aft-account-customizations/ACCOUNT_TEMPLATE/terraform/backend.jinja
+++ b/sources/aft-customizations-repos/aft-account-customizations/ACCOUNT_TEMPLATE/terraform/backend.jinja
@@ -11,7 +11,7 @@ terraform {
     dynamodb_table = "{{ dynamodb_table }}"
     encrypt        = "true"
     kms_key_id     = "{{ kms_key_id }}"
-    assume_role {
+    assume_role    = {
       role_arn     = "{{ aft_admin_role_arn }}"
     }
   }


### PR DESCRIPTION
Hi -- You aren't accepting contributions but this is a stupid easy bug to fix.

The example for `aft-account-customizations` has a jinja template that is syntactically invalid.

The `assume_role` block in the s3 backend should be a variable, not a block. That is to say, it needs an equals sign or it will fail.

Please fix this!
