### PR TITLE
Alternative workflow with plan, approve and apply for customizations pipeline

### DIFF
--- a/modules/aft-account-provisioning-framework/states/aft_account_provisioning_framework.asl.json
+++ b/modules/aft-account-provisioning-framework/states/aft_account_provisioning_framework.asl.json
@@ -6,7 +6,9 @@
       "Type": "Task",
       "Resource": "arn:${current_partition}:states:::lambda:invoke",
       "ResultPath": "$.persist_metadata",
-      "ResultSelector": {"StatusCode.$":"$.StatusCode"},
+      "ResultSelector": {
+        "StatusCode.$": "$.StatusCode"
+      },
       "Parameters": {
         "FunctionName": "${persist_metadata_function_name}",
         "Payload": {
@@ -17,7 +19,9 @@
       },
       "Catch": [
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "Next": "aft_account_provisioning_framework_notify_error"
         }
       ]
@@ -27,7 +31,9 @@
       "Type": "Task",
       "Resource": "arn:${current_partition}:states:::lambda:invoke",
       "ResultPath": "$.role",
-      "ResultSelector": {"Arn.$":"$.Payload"},
+      "ResultSelector": {
+        "Arn.$": "$.Payload"
+      },
       "Parameters": {
         "FunctionName": "${create_role_function_name}",
         "Payload": {
@@ -38,7 +44,9 @@
       },
       "Retry": [
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "BackoffRate": 1.5,
           "IntervalSeconds": 60,
           "MaxAttempts": 5
@@ -46,7 +54,9 @@
       ],
       "Catch": [
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "Next": "aft_account_provisioning_framework_notify_error"
         }
       ]
@@ -56,7 +66,9 @@
       "Type": "Task",
       "Resource": "arn:${current_partition}:states:::lambda:invoke",
       "ResultPath": "$.account_tags",
-      "ResultSelector": {"StatusCode.$":"$.StatusCode"},
+      "ResultSelector": {
+        "StatusCode.$": "$.StatusCode"
+      },
       "Parameters": {
         "FunctionName": "${tag_account_function_name}",
         "Payload": {
@@ -68,7 +80,9 @@
       },
       "Catch": [
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "Next": "aft_account_provisioning_framework_notify_error"
         }
       ]
@@ -78,7 +92,9 @@
       "Type": "Task",
       "Resource": "arn:${current_partition}:states:::lambda:invoke",
       "ResultPath": "$.account_metadata_ssm",
-      "ResultSelector": {"StatusCode.$":"$.StatusCode"},
+      "ResultSelector": {
+        "StatusCode.$": "$.StatusCode"
+      },
       "Parameters": {
         "FunctionName": "${account_metadata_ssm_function_name}",
         "Payload": {
@@ -90,7 +106,9 @@
       },
       "Catch": [
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "Next": "aft_account_provisioning_framework_notify_error"
         }
       ]
@@ -114,7 +132,9 @@
       },
       "Catch": [
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "Next": "run_create_pipeline?"
         }
       ]
@@ -141,6 +161,11 @@
             "Name": "VENDED_ACCOUNT_ID",
             "Type": "PLAINTEXT",
             "Value.$": "$.Input.account_info.account.id"
+          },
+          {
+            "Name": "WORKFLOW_TYPE",
+            "Type": "PLAINTEXT",
+            "Value.$": "$.Input.account_request.workflow_type"
           }
         ]
       },
@@ -152,7 +177,9 @@
       },
       "Catch": [
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "Next": "aft_account_provisioning_framework_notify_error"
         }
       ]

--- a/modules/aft-customizations/buildspecs/aft-account-customizations-terraform.yml
+++ b/modules/aft-customizations/buildspecs/aft-account-customizations-terraform.yml
@@ -23,7 +23,7 @@ phases:
       - |
         CUSTOMIZATION=$(aws dynamodb get-item --table-name aft-request-metadata --key "{\"id\": {\"S\": \"$VENDED_ACCOUNT_ID\"}}" --attributes-to-get "account_customizations_name" | jq --raw-output ".Item.account_customizations_name.S")
 
-      # Check if customization directory exists       
+      # Check if customization directory exists
       - |
         if [[ ! -z "$CUSTOMIZATION" ]]; then  
           if [[ ! -d "$DEFAULT_PATH/$CUSTOMIZATION" ]]; then
@@ -74,7 +74,6 @@ phases:
           $DEFAULT_PATH/aws-aft-core-framework/sources/scripts/creds.sh
         fi
 
-
   pre_build:
     on-failure: ABORT
     commands:
@@ -115,7 +114,11 @@ phases:
             cd $DEFAULT_PATH/$CUSTOMIZATION/terraform
             export AWS_PROFILE=aft-management-admin
             /opt/aft/bin/terraform init -no-color
-            /opt/aft/bin/terraform apply -no-color --auto-approve
+            if [[ "plan" == ${ACTION} ]] ; then
+              /opt/aft/bin/terraform plan -no-color
+            elif [[ "apply" == ${ACTION} ]] ; then
+              /opt/aft/bin/terraform apply -no-color --auto-approve
+            fi
           else
             TF_BACKEND_REGION=$(aws ssm get-parameter --name "/aft/config/oss-backend/primary-region" --query "Parameter.Value" --output text)
             TF_ORG_NAME=$(aws ssm get-parameter --name "/aft/config/terraform/org-name" --query "Parameter.Value" --output text)

--- a/modules/aft-customizations/buildspecs/aft-create-pipeline.yml
+++ b/modules/aft-customizations/buildspecs/aft-create-pipeline.yml
@@ -17,7 +17,6 @@ phases:
       - TF_DDB_TABLE=$(aws ssm get-parameter --name $SSM_TF_DDB_TABLE --query "Parameter.Value" --output text)
       - TF_VERSION=$(aws ssm get-parameter --name $SSM_TF_VERSION --query "Parameter.Value" --output text)
 
-
       # Configure Development SSH Key
       - |
         ssh_key_parameter=$(aws ssm get-parameter --name /aft/config/aft-ssh-key --with-decryption 2> /dev/null || echo "None")
@@ -69,4 +68,4 @@ phases:
     commands:
       - export AWS_PROFILE=aft-management-admin
       - terraform init -no-color
-      - terraform apply -var="account_id=$VENDED_ACCOUNT_ID" -no-color --auto-approve
+      - terraform apply -var="account_id=$VENDED_ACCOUNT_ID" -var="workflow_type=$WORKFLOW_TYPE" -no-color --auto-approve

--- a/modules/aft-customizations/buildspecs/aft-global-customizations-terraform.yml
+++ b/modules/aft-customizations/buildspecs/aft-global-customizations-terraform.yml
@@ -59,7 +59,7 @@ phases:
       # Mark helper scripts as executable
       - chmod +x $DEFAULT_PATH/api_helpers/pre-api-helpers.sh
       - chmod +x $DEFAULT_PATH/api_helpers/post-api-helpers.sh
-      
+
   pre_build:
     on-failure: ABORT
     commands:
@@ -97,7 +97,11 @@ phases:
           cd $DEFAULT_PATH/terraform
           export AWS_PROFILE=aft-management-admin
           /opt/aft/bin/terraform init -no-color
-          /opt/aft/bin/terraform apply -no-color --auto-approve
+          if [[ "plan" == ${ACTION} ]] ; then
+            /opt/aft/bin/terraform plan -no-color
+          elif [[ "apply" == ${ACTION} ]] ; then
+            /opt/aft/bin/terraform apply -no-color --auto-approve
+          fi
         else
           TF_ORG_NAME=$(aws ssm get-parameter --name "/aft/config/terraform/org-name" --query "Parameter.Value" --output text)
           TF_TOKEN=$(aws ssm get-parameter --name "/aft/config/terraform/token" --with-decryption --query "Parameter.Value" --output text)

--- a/sources/aft-customizations-common/templates/customizations_pipeline/codepipeline.tf
+++ b/sources/aft-customizations-common/templates/customizations_pipeline/codepipeline.tf
@@ -137,7 +137,7 @@ resource "aws_codepipeline" "aft_codecommit_customizations_codepipeline" {
   dynamic "stage" {
     for_each = local.workflow_type == "apply-with-approval" ? [1] : []
     content {
-      name = "Global-Customizations"
+      name = "Global-Customizations-1"
       action {
         name            = "Plan"
         category        = "Build"
@@ -168,7 +168,7 @@ resource "aws_codepipeline" "aft_codecommit_customizations_codepipeline" {
   dynamic "stage" {
     for_each = local.workflow_type == "apply-with-approval" ? [1] : []
     content {
-      name = "Global-Customizations"
+      name = "Global-Customizations-2"
       action {
         name            = "Approval"
         category        = "Approval"
@@ -184,7 +184,7 @@ resource "aws_codepipeline" "aft_codecommit_customizations_codepipeline" {
   dynamic "stage" {
     for_each = local.workflow_type == "apply-with-approval" ? [1] : []
     content {
-      name = "Global-Customizations"
+      name = "Global-Customizations-3"
       action {
         name            = "Apply"
         category        = "Build"
@@ -218,7 +218,7 @@ resource "aws_codepipeline" "aft_codecommit_customizations_codepipeline" {
   dynamic "stage" {
     for_each = local.workflow_type == "apply-with-approval" ? [1] : []
     content {
-      name = "Account-Customizations"
+      name = "Account-Customizations-1"
 
       action {
         name            = "Plan"
@@ -250,7 +250,7 @@ resource "aws_codepipeline" "aft_codecommit_customizations_codepipeline" {
   dynamic "stage" {
     for_each = local.workflow_type == "apply-with-approval" ? [1] : []
     content {
-      name = "Account-Customizations"
+      name = "Account-Customizations-2"
 
       action {
         name            = "Approval"
@@ -268,7 +268,7 @@ resource "aws_codepipeline" "aft_codecommit_customizations_codepipeline" {
   dynamic "stage" {
     for_each = local.workflow_type == "apply-with-approval" ? [1] : []
     content {
-      name = "Account-Customizations"
+      name = "Account-Customizations-3"
 
       action {
         name            = "Apply"

--- a/sources/aft-customizations-common/templates/customizations_pipeline/codepipeline.tf
+++ b/sources/aft-customizations-common/templates/customizations_pipeline/codepipeline.tf
@@ -55,54 +55,244 @@ resource "aws_codepipeline" "aft_codecommit_customizations_codepipeline" {
   }
 
   ##############################################################
+  # Workflow "apply"
+  ##############################################################
+
+  ##############################################################
   # Apply-AFT-Global-Customizations
   ##############################################################
 
-  stage {
-    name = "Global-Customizations"
-    action {
-      name            = "Apply"
-      category        = "Build"
-      owner           = "AWS"
-      provider        = "CodeBuild"
-      input_artifacts = ["source-aft-global-customizations"]
-      version         = "1"
-      run_order       = "2"
-      configuration = {
-        ProjectName = var.aft_global_customizations_terraform_codebuild_name
-        EnvironmentVariables = jsonencode([
-          {
-            name  = "VENDED_ACCOUNT_ID",
-            value = var.account_id,
-            type  = "PLAINTEXT"
-          }
-        ])
+  dynamic "stage" {
+    for_each = local.workflow_type == "apply" ? [1] : []
+    content {
+      name = "Global-Customizations"
+      action {
+        name            = "Apply"
+        category        = "Build"
+        owner           = "AWS"
+        provider        = "CodeBuild"
+        input_artifacts = ["source-aft-global-customizations"]
+        version         = "1"
+        run_order       = "2"
+        configuration = {
+          ProjectName = var.aft_global_customizations_terraform_codebuild_name
+          EnvironmentVariables = jsonencode([
+            {
+              name  = "VENDED_ACCOUNT_ID",
+              value = var.account_id,
+              type  = "PLAINTEXT"
+            },
+            {
+              name  = "ACTION",
+              value = "apply",
+              type  = "PLAINTEXT"
+            }
+          ])
+        }
       }
     }
   }
   ##############################################################
   # Apply-AFT-Account-Customizations
   ##############################################################
-  stage {
-    name = "Account-Customizations"
+  dynamic "stage" {
+    for_each = local.workflow_type == "apply" ? [1] : []
+    content {
+      name = "Account-Customizations"
 
-    action {
-      name            = "Apply"
-      category        = "Build"
-      owner           = "AWS"
-      provider        = "CodeBuild"
-      input_artifacts = ["source-aft-account-customizations"]
-      version         = "1"
-      run_order       = "2"
-      configuration = {
-        ProjectName = var.aft_account_customizations_terraform_codebuild_name
-        EnvironmentVariables = jsonencode([
-          {
-            name  = "VENDED_ACCOUNT_ID",
-            value = var.account_id,
-            type  = "PLAINTEXT"
-          }
-        ])
+      action {
+        name            = "Apply"
+        category        = "Build"
+        owner           = "AWS"
+        provider        = "CodeBuild"
+        input_artifacts = ["source-aft-account-customizations"]
+        version         = "1"
+        run_order       = "2"
+        configuration = {
+          ProjectName = var.aft_account_customizations_terraform_codebuild_name
+          EnvironmentVariables = jsonencode([
+            {
+              name  = "VENDED_ACCOUNT_ID",
+              value = var.account_id,
+              type  = "PLAINTEXT"
+            },
+            {
+              name  = "ACTION",
+              value = "apply",
+              type  = "PLAINTEXT"
+            }
+          ])
+        }
+      }
+    }
+  }
+
+  ##############################################################
+  # Workflow "apply-with-approval"
+  ##############################################################
+
+  ##############################################################
+  # Apply-AFT-Global-Customizations
+  ##############################################################
+  dynamic "stage" {
+    for_each = local.workflow_type == "apply-with-approval" ? [1] : []
+    content {
+      name = "Global-Customizations"
+      action {
+        name            = "Plan"
+        category        = "Build"
+        owner           = "AWS"
+        provider        = "CodeBuild"
+        input_artifacts = ["source-aft-global-customizations"]
+        version         = "1"
+        run_order       = "2"
+        configuration = {
+          ProjectName = var.aft_global_customizations_terraform_codebuild_name
+          EnvironmentVariables = jsonencode([
+            {
+              name  = "VENDED_ACCOUNT_ID",
+              value = var.account_id,
+              type  = "PLAINTEXT"
+            },
+            {
+              name  = "ACTION",
+              value = "plan",
+              type  = "PLAINTEXT"
+            }
+          ])
+        }
+      }
+    }
+  }
+
+  dynamic "stage" {
+    for_each = local.workflow_type == "apply-with-approval" ? [1] : []
+    content {
+      name = "Global-Customizations"
+      action {
+        name            = "Approval"
+        category        = "Approval"
+        owner           = "AWS"
+        provider        = "Manual"
+        input_artifacts = []
+        version         = "1"
+        run_order       = "3"
+      }
+    }
+  }
+
+  dynamic "stage" {
+    for_each = local.workflow_type == "apply-with-approval" ? [1] : []
+    content {
+      name = "Global-Customizations"
+      action {
+        name            = "Apply"
+        category        = "Build"
+        owner           = "AWS"
+        provider        = "CodeBuild"
+        input_artifacts = ["source-aft-global-customizations"]
+        version         = "1"
+        run_order       = "4"
+        configuration = {
+          ProjectName = var.aft_global_customizations_terraform_codebuild_name
+          EnvironmentVariables = jsonencode([
+            {
+              name  = "VENDED_ACCOUNT_ID",
+              value = var.account_id,
+              type  = "PLAINTEXT"
+            },
+            {
+              name  = "ACTION",
+              value = "apply",
+              type  = "PLAINTEXT"
+            }
+          ])
+        }
+      }
+    }
+  }
+
+  ##############################################################
+  # Apply-AFT-Account-Customizations
+  ##############################################################
+  dynamic "stage" {
+    for_each = local.workflow_type == "apply-with-approval" ? [1] : []
+    content {
+      name = "Account-Customizations"
+
+      action {
+        name            = "Plan"
+        category        = "Build"
+        owner           = "AWS"
+        provider        = "CodeBuild"
+        input_artifacts = ["source-aft-account-customizations"]
+        version         = "1"
+        run_order       = "5"
+        configuration = {
+          ProjectName = var.aft_account_customizations_terraform_codebuild_name
+          EnvironmentVariables = jsonencode([
+            {
+              name  = "VENDED_ACCOUNT_ID",
+              value = var.account_id,
+              type  = "PLAINTEXT"
+            },
+            {
+              name  = "ACTION",
+              value = "plan",
+              type  = "PLAINTEXT"
+            }
+          ])
+        }
+      }
+    }
+  }
+
+  dynamic "stage" {
+    for_each = local.workflow_type == "apply-with-approval" ? [1] : []
+    content {
+      name = "Account-Customizations"
+
+      action {
+        name            = "Approval"
+        category        = "Approval"
+        owner           = "AWS"
+        provider        = "Manual"
+        input_artifacts = []
+        version         = "1"
+        run_order       = "6"
+      }
+    }
+
+  }
+
+  dynamic "stage" {
+    for_each = local.workflow_type == "apply-with-approval" ? [1] : []
+    content {
+      name = "Account-Customizations"
+
+      action {
+        name            = "Apply"
+        category        = "Build"
+        owner           = "AWS"
+        provider        = "CodeBuild"
+        input_artifacts = ["source-aft-account-customizations"]
+        version         = "1"
+        run_order       = "7"
+        configuration = {
+          ProjectName = var.aft_account_customizations_terraform_codebuild_name
+          EnvironmentVariables = jsonencode([
+            {
+              name  = "VENDED_ACCOUNT_ID",
+              value = var.account_id,
+              type  = "PLAINTEXT"
+            },
+            {
+              name  = "ACTION",
+              value = "apply",
+              type  = "PLAINTEXT"
+            }
+          ])
+        }
       }
     }
   }

--- a/sources/aft-customizations-common/templates/customizations_pipeline/data.tf
+++ b/sources/aft-customizations-common/templates/customizations_pipeline/data.tf
@@ -9,6 +9,10 @@ data "aws_ssm_parameter" "aft_vcs_type" {
   name = "/aft/config/vcs/provider"
 }
 
+data "aws_ssm_parameter" "aft_tf_distribution" {
+  name = "/aft/config/terraform/distribution"
+}
+
 data "aws_ssm_parameter" "codeconnections_connection_arn" {
   name = "/aft/config/vcs/codeconnections-connection-arn"
 }

--- a/sources/aft-customizations-common/templates/customizations_pipeline/locals.tf
+++ b/sources/aft-customizations-common/templates/customizations_pipeline/locals.tf
@@ -1,0 +1,6 @@
+locals {
+  tf_distribution = nonsensitive(data.aws_ssm_parameter.aft_tf_distribution.value)
+
+  # workflow_type apply-with-approval is available only when terraform distribution is oss
+  workflow_type = local.tf_distribution != "oss" ? "apply" : var.workflow_type
+}

--- a/sources/aft-customizations-common/templates/customizations_pipeline/variables.tf
+++ b/sources/aft-customizations-common/templates/customizations_pipeline/variables.tf
@@ -11,6 +11,15 @@ variable "account_id" {
   description = "Account ID for which the pipeline is being created"
 }
 
+variable "workflow_type" {
+  type        = string
+  description = "Type of pipeline workflow, it can be apply, apply-with-approval"
+  validation {
+    condition     = var.workflow_type == "apply" || var.workflow_type == "apply-with-approval"
+    error_message = "The value must be apply or apply-with-approval."
+  }
+}
+
 variable "aft_tf_s3_bucket_ssm_path" {
   type        = string
   description = "SSM Parameter path for the AFT Terraform S3 Bucket"

--- a/sources/aft-customizations-repos/aft-account-request/terraform/modules/aft-account-request/ddb.tf
+++ b/sources/aft-customizations-repos/aft-account-request/terraform/modules/aft-account-request/ddb.tf
@@ -23,6 +23,7 @@ resource "aws_dynamodb_table_item" "account-request" {
     }
     account_tags                = { S = jsonencode(var.account_tags) }
     account_customizations_name = { S = var.account_customizations_name }
+    workflow_type               = { S = var.workflow_type }
     custom_fields               = { S = jsonencode(var.custom_fields) }
   })
 }

--- a/sources/aft-customizations-repos/aft-account-request/terraform/modules/aft-account-request/variables.tf
+++ b/sources/aft-customizations-repos/aft-account-request/terraform/modules/aft-account-request/variables.tf
@@ -48,3 +48,13 @@ variable "account_customizations_name" {
   default     = ""
   description = "The name of the account customizations to apply"
 }
+
+variable "workflow_type" {
+  type        = string
+  default     = "apply"
+  description = "Type of pipeline workflow, it can be apply, apply-with-approval"
+  validation {
+    condition     = var.workflow_type == "apply" || var.workflow_type == "apply-with-approval"
+    error_message = "The workflow_type must be apply or apply-with-approval."
+  }
+}


### PR DESCRIPTION
This feature is the implementation of the feature request #541.

It adds a new parameter `workflow_type` to the account request module. 
The parameter can be valued:
- `apply` (default)
- `apply-with-approval`

This parameter is saved with all other parameters in the DynamoDB table and is passed to the step function for the account creation and the customizations pipeline.

The `apply` value maintains unchanged the current behaviour, the customizations pipeline is created with the usual 3 stages.

When you specify `apply-with-approval`, the resulting customizations pipeline will have the following stages:
1. Source
2. Global-Customizations-1 (plan)
3. Global-Customizations-2 (approval)
4. Global-Customizations-3 (apply)
5. Account-Customizations-1 (plan)
6. Account-Customizations-2 (approval)
7. Account-Customizations-3 (apply)
