### PR TITLE
Fix: Add depends_on to ensure S3 replication waits for versioning

### DIFF
--- a/modules/aft-backend/main.tf
+++ b/modules/aft-backend/main.tf
@@ -34,6 +34,9 @@ resource "aws_s3_bucket" "secondary-backend-bucket" {
 }
 
 resource "aws_s3_bucket_replication_configuration" "primary-backend-bucket-replication" {
+
+  depends_on = [aws_s3_bucket_versioning.secondary-backend-bucket-versioning]
+
   count    = var.secondary_region == "" ? 0 : 1
   provider = aws.primary_region
   bucket   = aws_s3_bucket.primary-backend-bucket.id


### PR DESCRIPTION
Add depends_on to ensure S3 replication waits for versioning

# Contributing to the AWS Control Tower Account Factory for Terraform

Thank you for your interest in contributing to the AWS Control Tower Account Factory for Terraform.

At this time, we are not accepting contributions. If contributions are accepted in the future, the AWS Control Tower Account Factory for Terraform is released under the [Apache license](http://aws.amazon.com/apache2.0/) and any code submitted will be released under that license.

If you have a feature request, please create an issue using the Feature Request template, thanks!
