### PR TITLE
Fix: Add depends_on for versioning in S3 replication config

### DIFF
--- a/modules/aft-backend/main.tf
+++ b/modules/aft-backend/main.tf
@@ -34,6 +34,9 @@ resource "aws_s3_bucket" "secondary-backend-bucket" {
 }
 
 resource "aws_s3_bucket_replication_configuration" "primary-backend-bucket-replication" {
+
+  depends_on = [aws_s3_bucket_versioning.secondary-backend-bucket-versioning]
+
   count    = var.secondary_region == "" ? 0 : 1
   provider = aws.primary_region
   bucket   = aws_s3_bucket.primary-backend-bucket.id


### PR DESCRIPTION
## ✅ Title:
S3 Replication Fails Due to Missing `depends_on` for Versioning Resource

---

## 📄 Description:
While setting up AFT using this module, I encountered an issue with S3 replication:

`Error: creating S3 Bucket (...) Replication Configuration:
api error InvalidRequest: Destination bucket must have versioning enabled.`


Upon reviewing the code at:
`.terraform/modules/aft/modules/aft-backend/main.tf`

I found that the `aws_s3_bucket_replication_configuration` resource does not explicitly wait for the versioning of the destination bucket to be enabled.

---

## 💡 Proposed Fix:

Add the following `depends_on` to ensure correct ordering:

```hcl
resource "aws_s3_bucket_replication_configuration" "primary-backend-bucket-replication" {
  
  depends_on = [aws_s3_bucket_versioning.secondary-backend-bucket-versioning]

  ...
}

This ensures Terraform waits for the destination bucket versioning to be fully enabled before configuring replication, avoiding the InvalidRequest error.

---

✅ I have raised a pull request with this fix.
PR: 
Please review and merge it at your convenience. Happy to contribute!