### PR TITLE
fdakldsj

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 AWS Control Tower Account Factory for Terraform (AFT) follows a GitOps model to automate the processes of account provisioning and account updating in AWS Control Tower. You'll create an *account request* Terraform file, which provides the necessary input that triggers the AFT workflow for account provisioning.
 
 
+
 For more information on AFT, see [Overview of AWS Control Tower Account Factory for Terraform](https://docs.aws.amazon.com/controltower/latest/userguide/aft-overview.html)
 
 ## Getting started


### PR DESCRIPTION
# Contributing to the AWS Control Tower Account Factory for Terraform

Thank you for your interest in contributing to the AWS Control Tower Account Factory for Terraform.

At this time, we are not accepting contributions. If contributions are accepted in the future, the AWS Control Tower Account Factory for Terraform is released under the [Apache license](http://aws.amazon.com/apache2.0/) and any code submitted will be released under that license.

If you have a feature request, please create an issue using the Feature Request template, thanks!
