### PR TITLE
s3: Warning Invalid Attribute Combination

### DIFF
--- a/modules/aft-feature-options/s3.tf
+++ b/modules/aft-feature-options/s3.tf
@@ -47,6 +47,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "aft_logging_bucket_lifecycle_c
     noncurrent_version_expiration {
       noncurrent_days = var.log_archive_bucket_object_expiration_days
     }
+
+    filter {}
   }
 
 }


### PR DESCRIPTION
- fix the required empty filter
- other option is to allow it to be specified but defaults to `{}`
`
filter = var.s3_lifecycle_filter
`


- Fixes:
```
│ Warning: Invalid Attribute Combination
│ 
│   with module.aft.module.aft_feature_options.aws_s3_bucket_lifecycle_configuration.aft_logging_bucket_lifecycle_configuration,
│   on .terraform/modules/aft/modules/aft-feature-options/s3.tf line 40, in resource "aws_s3_bucket_lifecycle_configuration" "aft_logging_bucket_lifecycle_configuration":
│   40: resource "aws_s3_bucket_lifecycle_configuration" "aft_logging_bucket_lifecycle_configuration" {
│ 
│ No attribute specified when one (and only one) of [rule[0].filter,rule[0].prefix] is required
│ 
```