### PR TITLE
Fix the S3 AFT customizations key ID to use the ARN

### DIFF
--- a/modules/aft-customizations/s3.tf
+++ b/modules/aft-customizations/s3.tf
@@ -28,7 +28,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "aft-codepipeline-
 
   rule {
     apply_server_side_encryption_by_default {
-      kms_master_key_id = var.aft_kms_key_id
+      kms_master_key_id = var.aft_kms_key_arn
       sse_algorithm     = "aws:kms"
     }
   }


### PR DESCRIPTION
- Fix #565
- Replace the Encryption Key Name to Encryption Key ARN
