### PR TITLE
fix: Explicitly define IAM permission dependencies before Lambda invocation

### DIFF
--- a/modules/aft-lambda-layer/lambda.tf
+++ b/modules/aft-lambda-layer/lambda.tf
@@ -31,6 +31,12 @@ resource "aws_cloudwatch_log_group" "codebuild_trigger_loggroup" {
 data "aws_lambda_invocation" "trigger_codebuild_job" {
   function_name = aws_lambda_function.codebuild_trigger.function_name
 
+  depends_on = [
+    aws_iam_role.codebuild_trigger_lambda_role,
+    aws_iam_role_policy.codebuild_trigger_policy,
+    aws_iam_role_policy_attachment.codebuild_trigger_VPC_access
+  ]
+
   input = <<JSON
 {
   "codebuild_project_name": "${aws_codebuild_project.codebuild.name}"


### PR DESCRIPTION
related issue: https://github.com/aws-ia/terraform-aws-control_tower_account_factory/issues/614

### Root Cause
- `data.aws_lambda_invocation.trigger_codebuild_job` was being executed without waiting for IAM role and policy creation to complete
- The Lambda function was being invoked before IAM resources were propagated across AWS
- This issue becomes more pronounced when the Lambda function execution time is long

## Changes Made

### Modified File
- `terraform-aws-control_tower_account_factory/modules/aft-lambda-layer/lambda.tf`

### Change Details
Added the following dependencies to `data.aws_lambda_invocation.trigger_codebuild_job`:

```terraform
depends_on = [
  aws_iam_role.codebuild_trigger_lambda_role,
  aws_iam_role_policy.codebuild_trigger_policy,
  aws_iam_role_policy_attachment.codebuild_trigger_VPC_access
]
```