### PR TITLE
feat: add apply-with-approval workflow type with terraform plan gate

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -109,6 +109,8 @@ module "aft_code_repositories" {
   global_codebuild_timeout                        = var.global_codebuild_timeout
   aft_enable_vpc                                  = module.aft_account_request_framework.vpc_deployment
   codebuild_compute_type                          = var.aft_codebuild_compute_type
+  workflow_type                                   = var.workflow_type
+  approval_sns_topic_arn                          = local.approval_sns_topic_arn
 }
 
 module "aft_customizations" {
@@ -149,6 +151,7 @@ module "aft_customizations" {
   codebuild_compute_type                            = var.aft_codebuild_compute_type
   sns_topic_enable_cmk_encryption                   = var.sns_topic_enable_cmk_encryption
   sfn_s3_bucket_object_expiration_days              = var.sfn_s3_bucket_object_expiration_days
+  workflow_type                                     = var.workflow_type
 }
 
 module "aft_feature_options" {
@@ -226,6 +229,44 @@ module "aft_lambda_layer" {
   cloudwatch_log_group_enable_cmk_encryption        = var.cloudwatch_log_group_enable_cmk_encryption
 }
 
+##############################################################
+# Optional SNS topic for pipeline approval notifications
+##############################################################
+
+resource "aws_sns_topic" "aft_pipeline_approval" {
+  count    = var.approval_notification_email != null ? 1 : 0
+  provider = aws.aft_management
+  name     = "aft-pipeline-approval-notifications"
+}
+
+resource "aws_sns_topic_subscription" "aft_pipeline_approval_email" {
+  count     = var.approval_notification_email != null ? 1 : 0
+  provider  = aws.aft_management
+  topic_arn = aws_sns_topic.aft_pipeline_approval[0].arn
+  protocol  = "email"
+  endpoint  = var.approval_notification_email
+}
+
+resource "aws_sns_topic_policy" "aft_pipeline_approval" {
+  count    = var.approval_notification_email != null ? 1 : 0
+  provider = aws.aft_management
+  arn      = aws_sns_topic.aft_pipeline_approval[0].arn
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid       = "AllowCodePipelinePublish"
+      Effect    = "Allow"
+      Principal = { Service = "codepipeline.amazonaws.com" }
+      Action    = "sns:Publish"
+      Resource  = aws_sns_topic.aft_pipeline_approval[0].arn
+    }]
+  })
+}
+
+locals {
+  approval_sns_topic_arn = var.approval_notification_email != null ? aws_sns_topic.aft_pipeline_approval[0].arn : null
+}
+
 module "aft_ssm_parameters" {
   providers = {
     aws = aws.aft_management
@@ -298,4 +339,6 @@ module "aft_ssm_parameters" {
   gitlab_selfmanaged_url                                      = var.gitlab_selfmanaged_url
   aft_codepipeline_customizations_bucket_id                   = module.aft_customizations.aft_codepipeline_customizations_bucket_name
   aft_metrics_reporting                                       = var.aft_metrics_reporting
+  workflow_type                                               = var.workflow_type
+  approval_sns_topic_arn                                      = local.approval_sns_topic_arn
 }

--- a/modules/aft-code-repositories/buildspecs/ct-aft-account-provisioning-customizations.yml
+++ b/modules/aft-code-repositories/buildspecs/ct-aft-account-provisioning-customizations.yml
@@ -112,7 +112,11 @@ phases:
     commands:
       - |
         if [ $TF_DISTRIBUTION = "oss" ]; then
-          terraform apply -no-color --auto-approve
+          if [ "${TF_PLAN_ONLY:-false}" = "true" ]; then
+            terraform plan -no-color
+          else
+            terraform apply -no-color --auto-approve
+          fi
         fi
   post_build:
     commands:

--- a/modules/aft-code-repositories/buildspecs/ct-aft-account-request.yml
+++ b/modules/aft-code-repositories/buildspecs/ct-aft-account-request.yml
@@ -111,7 +111,11 @@ phases:
     commands:
       - |
         if [ $TF_DISTRIBUTION = "oss" ]; then
-          terraform apply -no-color --auto-approve
+          if [ "${TF_PLAN_ONLY:-false}" = "true" ]; then
+            terraform plan -no-color
+          else
+            terraform apply -no-color --auto-approve
+          fi
         fi
   post_build:
     commands:

--- a/modules/aft-code-repositories/codebuild.tf
+++ b/modules/aft-code-repositories/codebuild.tf
@@ -131,3 +131,145 @@ resource "aws_cloudwatch_log_group" "account_provisioning_customizations" {
   retention_in_days = var.cloudwatch_log_group_retention
   kms_key_id        = var.cloudwatch_log_group_enable_cmk_encryption ? var.aft_kms_key_arn : null
 }
+
+##############################################################
+# Plan-only CodeBuild projects (used when workflow_type = apply-with-approval)
+##############################################################
+
+resource "aws_cloudwatch_log_group" "account_request_plan" {
+  count             = var.workflow_type == "apply-with-approval" ? 1 : 0
+  name              = "/aws/codebuild/ct-aft-account-request-plan"
+  retention_in_days = var.cloudwatch_log_group_retention
+  kms_key_id        = var.cloudwatch_log_group_enable_cmk_encryption ? var.aft_kms_key_arn : null
+}
+
+resource "aws_codebuild_project" "account_request_plan" {
+  count          = var.workflow_type == "apply-with-approval" ? 1 : 0
+  depends_on     = [aws_cloudwatch_log_group.account_request_plan, time_sleep.iam_eventual_consistency]
+  name           = "ct-aft-account-request-plan"
+  description    = "Runs terraform plan for Account Requests before manual approval"
+  build_timeout  = tostring(var.global_codebuild_timeout)
+  service_role   = aws_iam_role.account_request_codebuild_role.arn
+  encryption_key = var.aft_kms_key_arn
+
+  artifacts {
+    type = "CODEPIPELINE"
+  }
+
+  environment {
+    compute_type                = var.codebuild_compute_type
+    image                       = "aws/codebuild/amazonlinux2-x86_64-standard:5.0"
+    type                        = "LINUX_CONTAINER"
+    image_pull_credentials_type = "CODEBUILD"
+
+    environment_variable {
+      name  = "AWS_PARTITION"
+      value = data.aws_partition.current.partition
+      type  = "PLAINTEXT"
+    }
+
+    environment_variable {
+      name  = "TF_PLAN_ONLY"
+      value = "true"
+      type  = "PLAINTEXT"
+    }
+  }
+
+  logs_config {
+    cloudwatch_logs {
+      group_name = aws_cloudwatch_log_group.account_request_plan[0].name
+    }
+
+    s3_logs {
+      status   = "ENABLED"
+      location = "${var.codepipeline_s3_bucket_name}/ct-aft-account-request-plan-logs"
+    }
+  }
+
+  source {
+    type      = "CODEPIPELINE"
+    buildspec = data.local_file.account_request_buildspec.content
+  }
+
+  dynamic "vpc_config" {
+    for_each = var.aft_enable_vpc ? [1] : []
+    content {
+      vpc_id             = var.vpc_id
+      subnets            = var.subnet_ids
+      security_group_ids = var.security_group_ids
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [project_visibility]
+  }
+}
+
+resource "aws_cloudwatch_log_group" "account_provisioning_customizations_plan" {
+  count             = var.workflow_type == "apply-with-approval" ? 1 : 0
+  name              = "/aws/codebuild/ct-aft-account-provisioning-customizations-plan"
+  retention_in_days = var.cloudwatch_log_group_retention
+  kms_key_id        = var.cloudwatch_log_group_enable_cmk_encryption ? var.aft_kms_key_arn : null
+}
+
+resource "aws_codebuild_project" "account_provisioning_customizations_plan" {
+  count          = var.workflow_type == "apply-with-approval" ? 1 : 0
+  depends_on     = [aws_cloudwatch_log_group.account_provisioning_customizations_plan, time_sleep.iam_eventual_consistency]
+  name           = "ct-aft-account-provisioning-customizations-plan"
+  description    = "Runs terraform plan for Account Provisioning Customizations before manual approval"
+  build_timeout  = tostring(var.global_codebuild_timeout)
+  service_role   = aws_iam_role.account_provisioning_customizations_codebuild_role.arn
+  encryption_key = var.aft_kms_key_arn
+
+  artifacts {
+    type = "CODEPIPELINE"
+  }
+
+  environment {
+    compute_type                = var.codebuild_compute_type
+    image                       = "aws/codebuild/amazonlinux2-x86_64-standard:5.0"
+    type                        = "LINUX_CONTAINER"
+    image_pull_credentials_type = "CODEBUILD"
+
+    environment_variable {
+      name  = "AWS_PARTITION"
+      value = data.aws_partition.current.partition
+      type  = "PLAINTEXT"
+    }
+
+    environment_variable {
+      name  = "TF_PLAN_ONLY"
+      value = "true"
+      type  = "PLAINTEXT"
+    }
+  }
+
+  logs_config {
+    cloudwatch_logs {
+      group_name = aws_cloudwatch_log_group.account_provisioning_customizations_plan[0].name
+    }
+
+    s3_logs {
+      status   = "ENABLED"
+      location = "${var.codepipeline_s3_bucket_name}/ct-aft-account-provisioning-customizations-plan-logs"
+    }
+  }
+
+  source {
+    type      = "CODEPIPELINE"
+    buildspec = data.local_file.account_provisioning_customizations_buildspec.content
+  }
+
+  dynamic "vpc_config" {
+    for_each = var.aft_enable_vpc ? [1] : []
+    content {
+      vpc_id             = var.vpc_id
+      subnets            = var.subnet_ids
+      security_group_ids = var.security_group_ids
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [project_visibility]
+  }
+}

--- a/modules/aft-code-repositories/codepipeline.tf
+++ b/modules/aft-code-repositories/codepipeline.tf
@@ -47,6 +47,43 @@ resource "aws_codepipeline" "codecommit_account_request" {
   ##############################################################
   # Apply Account Request
   ##############################################################
+  dynamic "stage" {
+    for_each = var.workflow_type == "apply-with-approval" ? [1] : []
+    content {
+      name = "Terraform-Plan"
+      action {
+        name             = "Plan"
+        category         = "Build"
+        owner            = "AWS"
+        provider         = "CodeBuild"
+        input_artifacts  = ["account-request"]
+        output_artifacts = ["account-request-plan-output"]
+        version          = "1"
+        configuration = {
+          ProjectName = "ct-aft-account-request-plan"
+        }
+      }
+    }
+  }
+
+  dynamic "stage" {
+    for_each = var.workflow_type == "apply-with-approval" ? [1] : []
+    content {
+      name = "Approval"
+      action {
+        name     = "ManualApproval"
+        category = "Approval"
+        owner    = "AWS"
+        provider = "Manual"
+        version  = "1"
+        configuration = merge(
+          { CustomData = "Approve to apply Terraform changes." },
+          var.approval_sns_topic_arn != null ? { NotificationArn = var.approval_sns_topic_arn } : {}
+        )
+      }
+    }
+  }
+
   stage {
     name = "terraform-apply"
 
@@ -159,6 +196,43 @@ resource "aws_codepipeline" "codeconnections_account_request" {
   ##############################################################
   # Apply Account Request
   ##############################################################
+  dynamic "stage" {
+    for_each = var.workflow_type == "apply-with-approval" ? [1] : []
+    content {
+      name = "Terraform-Plan"
+      action {
+        name             = "Plan"
+        category         = "Build"
+        owner            = "AWS"
+        provider         = "CodeBuild"
+        input_artifacts  = ["account-request"]
+        output_artifacts = ["account-request-plan-output"]
+        version          = "1"
+        configuration = {
+          ProjectName = "ct-aft-account-request-plan"
+        }
+      }
+    }
+  }
+
+  dynamic "stage" {
+    for_each = var.workflow_type == "apply-with-approval" ? [1] : []
+    content {
+      name = "Approval"
+      action {
+        name     = "ManualApproval"
+        category = "Approval"
+        owner    = "AWS"
+        provider = "Manual"
+        version  = "1"
+        configuration = merge(
+          { CustomData = "Approve to apply Terraform changes." },
+          var.approval_sns_topic_arn != null ? { NotificationArn = var.approval_sns_topic_arn } : {}
+        )
+      }
+    }
+  }
+
   stage {
     name = "terraform-apply"
 
@@ -224,6 +298,43 @@ resource "aws_codepipeline" "codecommit_account_provisioning_customizations" {
   ##############################################################
   # Account Provisioning Customizations - Terraform Apply
   ##############################################################
+  dynamic "stage" {
+    for_each = var.workflow_type == "apply-with-approval" ? [1] : []
+    content {
+      name = "Terraform-Plan"
+      action {
+        name             = "Plan"
+        category         = "Build"
+        owner            = "AWS"
+        provider         = "CodeBuild"
+        input_artifacts  = ["account-provisioning-customizations"]
+        output_artifacts = ["account-provisioning-customizations-plan-output"]
+        version          = "1"
+        configuration = {
+          ProjectName = "ct-aft-account-provisioning-customizations-plan"
+        }
+      }
+    }
+  }
+
+  dynamic "stage" {
+    for_each = var.workflow_type == "apply-with-approval" ? [1] : []
+    content {
+      name = "Approval"
+      action {
+        name     = "ManualApproval"
+        category = "Approval"
+        owner    = "AWS"
+        provider = "Manual"
+        version  = "1"
+        configuration = merge(
+          { CustomData = "Approve to apply Terraform changes." },
+          var.approval_sns_topic_arn != null ? { NotificationArn = var.approval_sns_topic_arn } : {}
+        )
+      }
+    }
+  }
+
   stage {
     name = "terraform-apply"
 
@@ -294,6 +405,43 @@ resource "aws_codepipeline" "codeconnections_account_provisioning_customizations
   ##############################################################
   # Account Provisioning Customizations - Terraform Apply
   ##############################################################
+  dynamic "stage" {
+    for_each = var.workflow_type == "apply-with-approval" ? [1] : []
+    content {
+      name = "Terraform-Plan"
+      action {
+        name             = "Plan"
+        category         = "Build"
+        owner            = "AWS"
+        provider         = "CodeBuild"
+        input_artifacts  = ["account-provisioning-customizations"]
+        output_artifacts = ["account-provisioning-customizations-plan-output"]
+        version          = "1"
+        configuration = {
+          ProjectName = "ct-aft-account-provisioning-customizations-plan"
+        }
+      }
+    }
+  }
+
+  dynamic "stage" {
+    for_each = var.workflow_type == "apply-with-approval" ? [1] : []
+    content {
+      name = "Approval"
+      action {
+        name     = "ManualApproval"
+        category = "Approval"
+        owner    = "AWS"
+        provider = "Manual"
+        version  = "1"
+        configuration = merge(
+          { CustomData = "Approve to apply Terraform changes." },
+          var.approval_sns_topic_arn != null ? { NotificationArn = var.approval_sns_topic_arn } : {}
+        )
+      }
+    }
+  }
+
   stage {
     name = "terraform-apply"
 

--- a/modules/aft-code-repositories/variables.tf
+++ b/modules/aft-code-repositories/variables.tf
@@ -109,3 +109,13 @@ variable "aft_enable_vpc" {
 variable "codebuild_compute_type" {
   type = string
 }
+
+variable "workflow_type" {
+  type    = string
+  default = "apply"
+}
+
+variable "approval_sns_topic_arn" {
+  type    = string
+  default = null
+}

--- a/modules/aft-customizations/buildspecs/aft-global-customizations-terraform.yml
+++ b/modules/aft-customizations/buildspecs/aft-global-customizations-terraform.yml
@@ -107,7 +107,11 @@ phases:
           cd $DEFAULT_PATH/terraform
           export AWS_PROFILE=aft-management-admin
           /opt/aft/bin/terraform init -no-color
-          /opt/aft/bin/terraform apply -no-color --auto-approve
+          if [ "${TF_PLAN_ONLY:-false}" = "true" ]; then
+            /opt/aft/bin/terraform plan -no-color
+          else
+            /opt/aft/bin/terraform apply -no-color --auto-approve
+          fi
         else
           TF_ORG_NAME=$(aws ssm get-parameter --name "/aft/config/terraform/org-name" --query "Parameter.Value" --output text)
           TF_TOKEN=$(aws ssm get-parameter --name "/aft/config/terraform/token" --with-decryption --query "Parameter.Value" --output text)
@@ -159,6 +163,9 @@ phases:
         if [[ $CODEBUILD_BUILD_SUCCEEDING == 0 ]]; then
           exit 1
         fi
-      - source $DEFAULT_PATH/api-helpers-venv/bin/activate
-      - export AWS_PROFILE=aft-target
-      - . $DEFAULT_PATH/api_helpers/post-api-helpers.sh || exit 1
+      - |
+        if [ "${TF_PLAN_ONLY:-false}" != "true" ]; then
+          source $DEFAULT_PATH/api-helpers-venv/bin/activate
+          export AWS_PROFILE=aft-target
+          . $DEFAULT_PATH/api_helpers/post-api-helpers.sh || exit 1
+        fi

--- a/modules/aft-customizations/codebuild.tf
+++ b/modules/aft-customizations/codebuild.tf
@@ -76,6 +76,79 @@ resource "aws_cloudwatch_log_group" "aft_global_customizations_terraform" {
 }
 
 #####################################################
+# AFT Global Customizations Terraform - Plan only
+#####################################################
+
+resource "aws_cloudwatch_log_group" "aft_global_customizations_terraform_plan" {
+  count             = var.workflow_type == "apply-with-approval" ? 1 : 0
+  name              = "/aws/codebuild/aft-global-customizations-terraform-plan"
+  retention_in_days = var.cloudwatch_log_group_retention
+  kms_key_id        = var.cloudwatch_log_group_enable_cmk_encryption ? var.aft_kms_key_arn : null
+}
+
+resource "aws_codebuild_project" "aft_global_customizations_terraform_plan" {
+  count          = var.workflow_type == "apply-with-approval" ? 1 : 0
+  depends_on     = [aws_cloudwatch_log_group.aft_global_customizations_terraform_plan, time_sleep.wait_for_iam_eventual_consistency]
+  name           = "aft-global-customizations-terraform-plan"
+  description    = "Runs terraform plan for global customizations before manual approval"
+  build_timeout  = tostring(var.global_codebuild_timeout)
+  service_role   = aws_iam_role.aft_codebuild_customizations_role.arn
+  encryption_key = var.aft_kms_key_arn
+
+  artifacts {
+    type = "CODEPIPELINE"
+  }
+
+  environment {
+    compute_type                = var.codebuild_compute_type
+    image                       = "aws/codebuild/amazonlinux2-x86_64-standard:5.0"
+    type                        = "LINUX_CONTAINER"
+    image_pull_credentials_type = "CODEBUILD"
+
+    environment_variable {
+      name  = "AWS_PARTITION"
+      value = data.aws_partition.current.partition
+      type  = "PLAINTEXT"
+    }
+
+    environment_variable {
+      name  = "TF_PLAN_ONLY"
+      value = "true"
+      type  = "PLAINTEXT"
+    }
+  }
+
+  logs_config {
+    cloudwatch_logs {
+      group_name = aws_cloudwatch_log_group.aft_global_customizations_terraform_plan[0].name
+    }
+
+    s3_logs {
+      status   = "ENABLED"
+      location = "${aws_s3_bucket.aft_codepipeline_customizations_bucket.id}/aft-global-customizations-terraform-plan-logs"
+    }
+  }
+
+  source {
+    type      = "CODEPIPELINE"
+    buildspec = data.local_file.aft_global_customizations_terraform.content
+  }
+
+  dynamic "vpc_config" {
+    for_each = var.aft_enable_vpc ? [1] : []
+    content {
+      vpc_id             = var.aft_vpc_id
+      subnets            = var.aft_vpc_private_subnets
+      security_group_ids = var.aft_vpc_default_sg
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [project_visibility]
+  }
+}
+
+#####################################################
 # AFT Account Customizations Terraform
 #####################################################
 

--- a/modules/aft-customizations/variables.tf
+++ b/modules/aft-customizations/variables.tf
@@ -135,3 +135,8 @@ variable "sns_topic_enable_cmk_encryption" {
 variable "sfn_s3_bucket_object_expiration_days" {
   type = number
 }
+
+variable "workflow_type" {
+  type    = string
+  default = "apply"
+}

--- a/modules/aft-ssm-parameters/ssm.tf
+++ b/modules/aft-ssm-parameters/ssm.tf
@@ -406,3 +406,15 @@ resource "aws_ssm_parameter" "aft_metrics_reporting_uuid" {
   value = random_uuid.metrics_reporting_uuid.result
   type  = "String"
 }
+
+resource "aws_ssm_parameter" "aft_pipeline_workflow_type" {
+  name  = "/aft/config/pipeline/workflow-type"
+  type  = "String"
+  value = var.workflow_type
+}
+
+resource "aws_ssm_parameter" "aft_pipeline_approval_sns_topic_arn" {
+  name  = "/aft/config/pipeline/approval-notification-topic-arn"
+  type  = "String"
+  value = coalesce(var.approval_sns_topic_arn, "")
+}

--- a/modules/aft-ssm-parameters/variables.tf
+++ b/modules/aft-ssm-parameters/variables.tf
@@ -267,3 +267,12 @@ variable "aft_metrics_reporting" {
 variable "aft_codepipeline_customizations_bucket_id" {
   type = string
 }
+
+variable "workflow_type" {
+  type = string
+}
+
+variable "approval_sns_topic_arn" {
+  type    = string
+  default = null
+}

--- a/sources/aft-customizations-common/templates/customizations_pipeline/codepipeline.tf
+++ b/sources/aft-customizations-common/templates/customizations_pipeline/codepipeline.tf
@@ -57,6 +57,49 @@ resource "aws_codepipeline" "aft_codecommit_customizations_codepipeline" {
   ##############################################################
   # Apply-AFT-Global-Customizations
   ##############################################################
+  dynamic "stage" {
+    for_each = data.aws_ssm_parameter.workflow_type.value == "apply-with-approval" ? [1] : []
+    content {
+      name = "Terraform-Plan"
+      action {
+        name            = "Plan"
+        category        = "Build"
+        owner           = "AWS"
+        provider        = "CodeBuild"
+        input_artifacts = ["source-aft-global-customizations"]
+        output_artifacts = ["global-customizations-plan-output"]
+        version         = "1"
+        configuration = {
+          ProjectName = var.aft_global_customizations_terraform_plan_codebuild_name
+          EnvironmentVariables = jsonencode([
+            {
+              name  = "VENDED_ACCOUNT_ID",
+              value = var.account_id,
+              type  = "PLAINTEXT"
+            }
+          ])
+        }
+      }
+    }
+  }
+
+  dynamic "stage" {
+    for_each = data.aws_ssm_parameter.workflow_type.value == "apply-with-approval" ? [1] : []
+    content {
+      name = "Approval"
+      action {
+        name     = "ManualApproval"
+        category = "Approval"
+        owner    = "AWS"
+        provider = "Manual"
+        version  = "1"
+        configuration = merge(
+          { CustomData = "Approve to apply Terraform changes." },
+          local.approval_sns_topic_arn != null ? { NotificationArn = local.approval_sns_topic_arn } : {}
+        )
+      }
+    }
+  }
 
   stage {
     name = "Global-Customizations"
@@ -172,6 +215,49 @@ resource "aws_codepipeline" "aft_codeconnections_customizations_codepipeline" {
   ##############################################################
   # Apply-AFT-Global-Customizations
   ##############################################################
+  dynamic "stage" {
+    for_each = data.aws_ssm_parameter.workflow_type.value == "apply-with-approval" ? [1] : []
+    content {
+      name = "Terraform-Plan"
+      action {
+        name             = "Plan"
+        category         = "Build"
+        owner            = "AWS"
+        provider         = "CodeBuild"
+        input_artifacts  = ["source-aft-global-customizations"]
+        output_artifacts = ["global-customizations-plan-output"]
+        version          = "1"
+        configuration = {
+          ProjectName = var.aft_global_customizations_terraform_plan_codebuild_name
+          EnvironmentVariables = jsonencode([
+            {
+              name  = "VENDED_ACCOUNT_ID",
+              value = var.account_id,
+              type  = "PLAINTEXT"
+            }
+          ])
+        }
+      }
+    }
+  }
+
+  dynamic "stage" {
+    for_each = data.aws_ssm_parameter.workflow_type.value == "apply-with-approval" ? [1] : []
+    content {
+      name = "Approval"
+      action {
+        name     = "ManualApproval"
+        category = "Approval"
+        owner    = "AWS"
+        provider = "Manual"
+        version  = "1"
+        configuration = merge(
+          { CustomData = "Approve to apply Terraform changes." },
+          local.approval_sns_topic_arn != null ? { NotificationArn = local.approval_sns_topic_arn } : {}
+        )
+      }
+    }
+  }
 
   stage {
     name = "AFT-Global-Customizations"

--- a/sources/aft-customizations-common/templates/customizations_pipeline/data.tf
+++ b/sources/aft-customizations-common/templates/customizations_pipeline/data.tf
@@ -45,3 +45,11 @@ data "aws_s3_bucket" "aft_codepipeline_customizations_bucket" {
 data "aws_ssm_parameter" "vcs_provider" {
   name = "/aft/config/vcs/provider"
 }
+
+data "aws_ssm_parameter" "workflow_type" {
+  name = "/aft/config/pipeline/workflow-type"
+}
+
+data "aws_ssm_parameter" "approval_sns_topic_arn" {
+  name = "/aft/config/pipeline/approval-notification-topic-arn"
+}

--- a/sources/aft-customizations-common/templates/customizations_pipeline/variables.tf
+++ b/sources/aft-customizations-common/templates/customizations_pipeline/variables.tf
@@ -5,6 +5,13 @@ locals {
   vcs = {
     is_codecommit = lower(data.aws_ssm_parameter.vcs_provider.value) == "codecommit" ? true : false
   }
+  approval_sns_topic_arn = data.aws_ssm_parameter.approval_sns_topic_arn.value != "" ? data.aws_ssm_parameter.approval_sns_topic_arn.value : null
+}
+
+variable "aft_global_customizations_terraform_plan_codebuild_name" {
+  type        = string
+  description = "CodeBuild Project Name for the global customizations plan stage"
+  default     = "aft-global-customizations-terraform-plan"
 }
 variable "account_id" {
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -525,3 +525,19 @@ variable "aft_metrics_reporting" {
     error_message = "Valid values for var: aft_metrics_reporting are (true, false)."
   }
 }
+
+variable "workflow_type" {
+  description = "Workflow type for AFT pipelines — 'apply' for auto-approve, 'apply-with-approval' for a manual gate before every terraform-apply stage"
+  type        = string
+  default     = "apply"
+  validation {
+    condition     = contains(["apply", "apply-with-approval"], var.workflow_type)
+    error_message = "Valid values for var: workflow_type are (apply, apply-with-approval)."
+  }
+}
+
+variable "approval_notification_email" {
+  description = "Email address to notify when a pipeline is awaiting manual approval. Only used when workflow_type is 'apply-with-approval'. Requires subscription confirmation after deployment."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
 ## Summary

 - Adds a `workflow_type` variable (`"apply"` default, `"apply-with-approval"`) that gates every AFT pipeline behind a **Terraform Plan → Manual Approval** sequence before applying
 - Adds an optional `approval_notification_email` variable that creates an SNS topic + email subscription to notify approvers when a pipeline is waiting
 - All changes are fully backward-compatible — existing deployments with `workflow_type = "apply"` (the default) are unaffected

 ## Pipeline flow when `workflow_type = "apply-with-approval"`

 Source → Terraform-Plan (CodeBuild) → Approval (Manual) → terraform-apply

 Applies to all three pipeline types:
 - `ct-aft-account-request`
 - `ct-aft-account-provisioning-customizations`
 - `{account_id}-customizations-pipeline` (per-account, both global + account customization stages)

 ## How to use

 ```hcl
 module "aft" {
   # ... existing vars ...
   workflow_type               = "apply-with-approval"
   approval_notification_email = "platform-team@example.com"  # optional
 }
```


##  Technical details

 - Plan CodeBuild projects (ct-aft-account-request-plan, ct-aft-account-provisioning-customizations-plan, aft-global-customizations-terraform-plan) are created with count conditional on
 workflow_type — no idle resources when using the default "apply" mode
 - TF_PLAN_ONLY=true env var on plan projects reuses the existing buildspecs without duplication; post-api-helpers.sh is skipped during plan runs to avoid executing post-apply hooks on a dry
 run
 - Per-account pipeline template reads workflow_type from SSM (/aft/config/pipeline/workflow-type) — consistent with how all other config flows into that template
 - SNS topic policy grants codepipeline.amazonaws.com publish rights; no IAM role changes required

##  Test plan

 - terraform plan with workflow_type = "apply" — no diff on existing pipeline resources
 - terraform plan with workflow_type = "apply-with-approval" — confirm Plan + Approval stages appear in pipeline diff, plan CodeBuild projects created
 - Trigger a pipeline, confirm it pauses at Approval; approve → apply runs successfully
 - Set approval_notification_email — confirm SNS topic, subscription, and topic policy are created
 - Trigger aft-create-pipeline for a vended account — confirm per-account pipeline includes Plan + Approval stages